### PR TITLE
Fix null integral problems

### DIFF
--- a/src/functions/commutative/CommutativeFunction.java
+++ b/src/functions/commutative/CommutativeFunction.java
@@ -103,7 +103,7 @@ public abstract class CommutativeFunction extends GeneralFunction {
 	 * Simplifies each element of this {@link CommutativeFunction}
 	 * @return a new {@link CommutativeFunction} with each element of {@link #functions} simplified
 	 */
-	public abstract CommutativeFunction simplifyElements();
+	public abstract CommutativeFunction simplifyElements(); // TODO make be here
 
 	/**
 	 * Removes all instances of {@link #identityValue} from {@link #functions}

--- a/src/functions/commutative/CommutativeFunction.java
+++ b/src/functions/commutative/CommutativeFunction.java
@@ -103,7 +103,12 @@ public abstract class CommutativeFunction extends GeneralFunction {
 	 * Simplifies each element of this {@link CommutativeFunction}
 	 * @return a new {@link CommutativeFunction} with each element of {@link #functions} simplified
 	 */
-	public abstract CommutativeFunction simplifyElements(); // TODO make be here
+	public CommutativeFunction simplifyElements() {
+		GeneralFunction[] simplifiedFunctions = new GeneralFunction[functions.length];
+		for (int i = 0; i < functions.length; i++)
+			simplifiedFunctions[i] = functions[i].simplify();
+		return getInstance(simplifiedFunctions);
+	}
 
 	/**
 	 * Removes all instances of {@link #identityValue} from {@link #functions}

--- a/src/functions/commutative/Product.java
+++ b/src/functions/commutative/Product.java
@@ -189,7 +189,7 @@ public class Product extends CommutativeFunction {
 				}
 			}
 
-			return new Product(newFunctions.toArray(new GeneralFunction[0]));
+			return new Product(newFunctions.toArray(new GeneralFunction[0])).simplifyInternal();
 		} else {
 			return this;
 		}

--- a/src/functions/commutative/Product.java
+++ b/src/functions/commutative/Product.java
@@ -103,12 +103,6 @@ public class Product extends CommutativeFunction {
 		return current;
 	}
 
-	@Override
-	public Product simplifyElements() {
-		GeneralFunction[] toMultiply = new GeneralFunction[functions.length];
-		for (int i = 0; i < functions.length; i++) toMultiply[i] = functions[i].simplify();
-		return new Product(toMultiply);
-	}
 
 	/**
 	 * Returns true if the {@link Product} contains a {@link Constant} with value {@code 0}

--- a/src/functions/commutative/Sum.java
+++ b/src/functions/commutative/Sum.java
@@ -66,15 +66,6 @@ public class Sum extends CommutativeFunction {
 		return current;
 	}
 
-
-	@Override
-	public Sum simplifyElements() {
-		GeneralFunction[] toAdd = new GeneralFunction[functions.length];
-		for (int i = 0; i < functions.length; i++)
-			toAdd[i] = functions[i].simplify();
-		return new Sum(toAdd);
-	}
-
 	/**
 	 * Returns a {@link Sum} where like terms are added together. Ex: {@code 2x+x=3x}
 	 * @return a {@link Sum} where like terms are added together

--- a/src/functions/unitary/transforms/Differential.java
+++ b/src/functions/unitary/transforms/Differential.java
@@ -72,6 +72,10 @@ public class Differential extends TransformFunction {
 	}
 
 
+	public UnitaryFunction simplify() {
+		return this;
+	}
+
 	@Override
 	public UnitaryFunction simplifyInternal() {
 		return this;

--- a/src/functions/unitary/transforms/Differential.java
+++ b/src/functions/unitary/transforms/Differential.java
@@ -9,7 +9,7 @@ import java.util.Map;
 public class Differential extends TransformFunction {
 
 	/**
-	 * Returns a new {@link Differential}, which is sometimes used as an intermediary for integrals and derivatives
+	 * Constructs a new {@link Differential}, which is sometimes used as an intermediary for integrals and derivatives
 	 * @param operand the operand of the {@link Differential}, which must be a variable
 	 * @param respectTo the variable that the differential is with respect to, which must match the variable
 	 */
@@ -19,6 +19,22 @@ public class Differential extends TransformFunction {
 			throw new UnsupportedOperationException("Created a differential with a non-variable operand " + operand);
 	}
 
+	/**
+	 * Constructs a new {@link Differential}, which is sometimes used as an intermediary for integrals and derivatives
+	 * @param respectTo the variable that the differential is with respect to
+	 */
+	public Differential(char respectTo) {
+		super(null, respectTo);
+	}
+
+	/**
+	 * Constructs a new {@link Differential}, which is sometimes used as an intermediary for integrals and derivatives, using a {@link Variable}
+	 * @param operand the variable that the differential is with respect to
+	 */
+	public Differential(Variable operand) {
+		this(operand.varID);
+	}
+
 	@Override
 	public String toString() {
 		return "d" + respectTo;
@@ -26,7 +42,7 @@ public class Differential extends TransformFunction {
 
 	@Override
 	public UnitaryFunction clone() {
-		return new Differential(operand.clone(), respectTo);
+		return new Differential(respectTo);
 	}
 
 	@Override
@@ -74,7 +90,9 @@ public class Differential extends TransformFunction {
 
 
 	public UnitaryFunction getInstance(GeneralFunction function) {
-		return new Differential(function, respectTo);
+		if (!(function instanceof Variable))
+			throw new IllegalArgumentException("Cannot create a differential with respect to non-variable function " + function);
+		return new Differential((Variable) function);
 	}
 
 	/**

--- a/src/functions/unitary/transforms/Differential.java
+++ b/src/functions/unitary/transforms/Differential.java
@@ -10,17 +10,6 @@ public class Differential extends TransformFunction {
 
 	/**
 	 * Constructs a new {@link Differential}, which is sometimes used as an intermediary for integrals and derivatives
-	 * @param operand the operand of the {@link Differential}, which must be a variable
-	 * @param respectTo the variable that the differential is with respect to, which must match the variable
-	 */
-	public Differential(GeneralFunction operand, char respectTo) {
-		super(operand, respectTo);
-		if (!(operand instanceof Variable))
-			throw new UnsupportedOperationException("Created a differential with a non-variable operand " + operand);
-	}
-
-	/**
-	 * Constructs a new {@link Differential}, which is sometimes used as an intermediary for integrals and derivatives
 	 * @param respectTo the variable that the differential is with respect to
 	 */
 	public Differential(char respectTo) {

--- a/src/functions/unitary/transforms/Integral.java
+++ b/src/functions/unitary/transforms/Integral.java
@@ -1,7 +1,10 @@
 package functions.unitary.transforms;
 
 import functions.GeneralFunction;
+import functions.commutative.Product;
 import functions.unitary.UnitaryFunction;
+import tools.ArrayTools;
+import tools.DefaultFunctions;
 import tools.exceptions.IntegrationFailedException;
 import tools.integration.StageOne;
 import tools.singlevariable.NumericalIntegration;
@@ -17,6 +20,14 @@ public class Integral extends TransformFunction { // TODO figure out why the par
 	 */
 	public Integral(GeneralFunction integrand, char respectTo) {
 		super(integrand, respectTo);
+	}
+
+	/**
+	 * Constructs a new {@link Integral} whose {@code respectTo} is {@code null}. This WILL THROW AN EXCEPTION if any method is attempted that uses {@code respectTo}.
+	 * @param integrand the integrand of the {@link Integral}
+	 */
+	public Integral(GeneralFunction integrand) {
+		super(integrand, null);
 	}
 
 	@Override
@@ -93,5 +104,30 @@ public class Integral extends TransformFunction { // TODO figure out why the par
 	 */
 	public GeneralFunction execute() throws IntegrationFailedException {
 		return StageOne.derivativeDivides(operand, respectTo).simplify();
+	}
+
+	public GeneralFunction simplify() {
+		if (respectTo == null) {
+			return fixNull();
+		} else {
+			return super.simplify();
+		}
+	}
+
+	@SuppressWarnings("ChainOfInstanceofChecks")
+	private GeneralFunction fixNull() {
+		if (operand instanceof Differential diff) {
+			return new Integral(DefaultFunctions.ONE, diff.respectTo);
+		} else if (operand instanceof Product product) {
+			GeneralFunction[] functions = product.getFunctions();
+			for (int i = 0; i < functions.length; i++) {
+				if (functions[i] instanceof Differential diff) {
+					return new Integral(new Product(ArrayTools.removeFunctionAt(functions, i)), diff.respectTo).simplify();
+				}
+			}
+			return this;
+		} else {
+			return this;
+		}
 	}
 }

--- a/src/functions/unitary/transforms/TransformFunction.java
+++ b/src/functions/unitary/transforms/TransformFunction.java
@@ -9,14 +9,14 @@ public abstract class TransformFunction extends UnitaryFunction {
 	/**
 	 * The character of the variable that the {@link TransformFunction} is with respect to
 	 */
-	public final char respectTo;
+	public final Character respectTo;
 
 	/**
 	 * Constructs a new {@link TransformFunction}
 	 * @param operand the operand of the {@link TransformFunction}
 	 * @param respectTo the variable that the {@link TransformFunction} operates with respect to
 	 */
-	public TransformFunction(GeneralFunction operand, char respectTo) {
+	public TransformFunction(GeneralFunction operand, Character respectTo) {
 		super(operand);
 		this.respectTo = respectTo;
 	}

--- a/src/parsing/FunctionMaker.java
+++ b/src/parsing/FunctionMaker.java
@@ -35,6 +35,7 @@ public class FunctionMaker {
 			case "/" 			-> new Pow(DefaultFunctions.NEGATIVE_ONE, function);
 			case "!" 			-> Factorial.defaultFactorial(function);
 			case "\\ln" 		-> new Ln(function);
+			case "\\int" 		-> new Integral(function);
 			case "\\log"		-> new Logb(function, DefaultFunctions.TEN);
 			case "\\exp" 		-> new Exp(function);
 			case "\\abs" 		-> new Abs(function);
@@ -85,7 +86,6 @@ public class FunctionMaker {
 			case "C" 		-> new Product(Factorial.defaultFactorial(first), new Pow(DefaultFunctions.NEGATIVE_ONE, new Product(Factorial.defaultFactorial(second), Factorial.defaultFactorial(new Sum(first, new Product(DefaultFunctions.NEGATIVE_ONE, second))))));
 			case "P" 		-> new Product(Factorial.defaultFactorial(first), new Pow(DefaultFunctions.NEGATIVE_ONE, Factorial.defaultFactorial(new Sum(first, new Product(DefaultFunctions.NEGATIVE_ONE, second)))));
 			case "\\pd"		-> new PartialDerivative(second, ((Variable) first).varID);
-			case "\\int" 	-> new Integral(first, ((Differential) second).getRespectTo());
 			case "\\logb" 	-> new Logb(second, first);
 			case "\\frac" 	-> new Product(first, DefaultFunctions.reciprocal(second));
 			default 		-> throw new UnsupportedOperationException("Invalid functionName " + functionName);

--- a/src/parsing/FunctionMaker.java
+++ b/src/parsing/FunctionMaker.java
@@ -38,7 +38,7 @@ public class FunctionMaker {
 			case "\\log"		-> new Logb(function, DefaultFunctions.TEN);
 			case "\\exp" 		-> new Exp(function);
 			case "\\abs" 		-> new Abs(function);
-			case "\\difn"		-> new Differential(function, ((Variable) function).varID);
+			case "\\difn"		-> new Differential((Variable) function);
 			case "\\sqrt" 		-> new Pow(DefaultFunctions.HALF, function);
 			case "\\sign" 		-> new Sign(function);
 			case "\\dirac" 		-> new Dirac(function);

--- a/src/parsing/InfixTokenizer.java
+++ b/src/parsing/InfixTokenizer.java
@@ -69,6 +69,8 @@ public class InfixTokenizer {
 		infix = endPD.matcher(partialDerivative.matcher(infix).replaceAll("\\\\pd{")).replaceAll("}");
 		// Make absolute values into unitary functions
 		infix = absoluteValueStart.matcher(absoluteValueEnd.matcher(infix).replaceAll(")")).replaceAll("*\\abs(").replace("|", " \\abs(");
+		// Replaces brackets with parentheses
+		infix = infix.replace("[", "(").replace("]", ")");
 		// Insert multiplication in expressions like 2x and 7(x*y+1)sin(3y)
 		infix = adjacentMultiplier.matcher(infix).replaceAll(" * ");
 		// Turns expressions like x-y into x+-y, and turns expressions like x*y into x*/y (the '/' operator represents reciprocals)
@@ -77,8 +79,10 @@ public class InfixTokenizer {
 		infix = differential.matcher(infix).replaceAll("\\\\difn ");
 		// Turns expressions like xyz into x*y*z
 		infix = characterPairsToMultiply.matcher(infix).replaceAll(" * ");
-		// Replace curly braces and underscores with parentheses and spaces
-		infix = infix.replace("{", "(").replace("}", ")").replace("[", "(").replace("]", ")").replace("_", " ");
+		// Replace curly braces parentheses
+		infix = infix.replace("{", "(").replace("}", ")");
+		// Replaces underscores with spaces
+		infix = infix.replace("_", " ");
 		// Adds parentheses to enforce order of operations
 		infix = "((((" + times.matcher(plus.matcher(closeParen.matcher(openParen.matcher(infix).replaceAll("((((")).replaceAll("))))")).replaceAll("))+((")).replaceAll(")*(") + "))))";
 		// Splits infix into tokens

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -99,6 +99,7 @@ public class KeywordInterface {
 		switch (input) {
 			case "fp", "parse", "parser"  -> {
 				Scanner scanner = new Scanner(System.in);
+				scanner.useDelimiter("\n");
 				input = scanner.next();
 				while (!"exit".equals(input) && !"!".equals(input)) {
 					try {

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -104,11 +104,11 @@ public class KeywordInterface {
 					try {
 						System.out.println("PSto: " + parseStored(input));
 					} catch (Exception e) {
-						System.out.println(e.toString());
+						e.printStackTrace();
 					} try {
 						System.out.println("PSim: " + FunctionParser.parseSimplified(input));
 					} catch (Exception e) {
-						System.out.println(e.toString());
+						e.printStackTrace();
 					}
 					input = scanner.next();
 				}

--- a/src/parsing/OperationLists.java
+++ b/src/parsing/OperationLists.java
@@ -18,6 +18,7 @@ public class OperationLists {
 			add("/");
 			add("!");
 			add("\\ln");
+			add("\\int");
 			add("\\log");
 			add("\\exp");
 			add("\\abs");
@@ -63,7 +64,6 @@ public class OperationLists {
 			add("C");
 			add("P");
 			add("\\pd");
-			add("\\int");
 			add("\\logb");
 			add("\\frac");
 		}

--- a/tests/DifferentialTest.java
+++ b/tests/DifferentialTest.java
@@ -32,11 +32,17 @@ public class DifferentialTest {
 	}
 
 	@Test
-	void integralNull() {
+	void integralNullException() {
 		Integral test = new Integral(parseSimplified("x"));
 		assertThrows(Exception.class, test::execute);
-		assertThrows(Exception.class, test::simplify);
 		assertThrows(Exception.class, () -> test.substituteVariable('x', parseSimplified("y")));
+		test.simplify();
+	}
+
+	@Test
+	void integralDifferentialInside() {
+		Integral test = new Integral(parseInfix("x\\dx"));
+		assertEquals(parseInfix("x^2/2"), test.simplify());
 	}
 
 }

--- a/tests/DifferentialTest.java
+++ b/tests/DifferentialTest.java
@@ -1,6 +1,9 @@
 import functions.GeneralFunction;
+import functions.commutative.Product;
+import functions.unitary.transforms.Differential;
 import functions.unitary.transforms.Integral;
 import org.junit.jupiter.api.Test;
+import tools.DefaultFunctions;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static parsing.FunctionParser.parseInfix;
@@ -42,6 +45,12 @@ public class DifferentialTest {
 	@Test
 	void integralDifferentialInside() {
 		Integral test = new Integral(parseInfix("x\\dx"));
+		assertEquals(parseInfix("x^2/2"), test.simplify());
+	}
+
+	@Test
+	void differentialProductIntegral() {
+		GeneralFunction test = new Product(new Integral(DefaultFunctions.X), new Differential('x'));
 		assertEquals(parseInfix("x^2/2"), test.simplify());
 	}
 

--- a/tests/DifferentialTest.java
+++ b/tests/DifferentialTest.java
@@ -2,9 +2,9 @@ import functions.GeneralFunction;
 import functions.unitary.transforms.Integral;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static parsing.FunctionParser.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static parsing.FunctionParser.parseInfix;
+import static parsing.FunctionParser.parseSimplified;
 
 public class DifferentialTest {
 	@Test
@@ -29,6 +29,14 @@ public class DifferentialTest {
 	void integral1() {
 		GeneralFunction test = parseInfix("\\int[2x]\\dx");
 		assertTrue(test instanceof Integral);
+	}
+
+	@Test
+	void integralNull() {
+		Integral test = new Integral(parseSimplified("x"));
+		assertThrows(Exception.class, test::execute);
+		assertThrows(Exception.class, test::simplify);
+		assertThrows(Exception.class, () -> test.substituteVariable('x', parseSimplified("y")));
 	}
 
 }

--- a/tests/DifferentialTest.java
+++ b/tests/DifferentialTest.java
@@ -31,7 +31,7 @@ public class DifferentialTest {
 	@Test
 	void integral1() {
 		GeneralFunction test = parseInfix("\\int[2x]\\dx");
-		assertTrue(test instanceof Integral);
+		assertEquals(parseInfix("x^2"), test.simplify());
 	}
 
 	@Test
@@ -52,6 +52,12 @@ public class DifferentialTest {
 	void differentialProductIntegral() {
 		GeneralFunction test = new Product(new Integral(DefaultFunctions.X), new Differential('x'));
 		assertEquals(parseInfix("x^2/2"), test.simplify());
+	}
+
+	@Test
+	void differentialProductIntegral2() {
+		GeneralFunction test = new Product(DefaultFunctions.TWO, new Integral(DefaultFunctions.X), new Differential('x'));
+		assertEquals(parseInfix("x^2"), test.simplify());
 	}
 
 }


### PR DESCRIPTION
This branch solves the problems of null integrals and products of integrals by adding a few simplification steps:
Let `\int(function)d0` be an integral with respect to `null`, `\int(function)dv` be an integral with respect to `v`, and `\d(v)` be a differential with respect to `v`:
1. Simplifies expressions of the form `something * \int(function)d0 * \d(v)` to `something * \int(function)dv`
2. Simplifies expressions of the form `\int(function * \d(v))d0` to `\int(function)dv`