### PR TITLE
Add NoEscapeTest and make all other tests escaped

### DIFF
--- a/tests/LatexTest.java
+++ b/tests/LatexTest.java
@@ -1,4 +1,3 @@
-import config.Settings;
 import functions.GeneralFunction;
 import org.junit.jupiter.api.Test;
 import parsing.FunctionParser;
@@ -56,15 +55,6 @@ public class LatexTest {
 	void log() {
 		GeneralFunction test = FunctionParser.parseInfix("\\log(x)+\\log(1)");
 		assertEquals(1, test.evaluate(Map.of('x', 10.0)), .3);
-	}
-
-	@Test
-	void noEscape() {
-		boolean temp = Settings.enforceEscapes;
-		Settings.enforceEscapes = false;
-		GeneralFunction test = FunctionParser.parseInfix("pi (1+1)+sin(pi/2)");
-		assertEquals(7.3, test.evaluate(Map.of('x', 3.2)), .3);
-		Settings.enforceEscapes = temp;
 	}
 
 }

--- a/tests/NoEscapeTest.java
+++ b/tests/NoEscapeTest.java
@@ -1,0 +1,97 @@
+import config.Settings;
+import functions.GeneralFunction;
+import functions.commutative.Product;
+import org.junit.jupiter.api.Test;
+import parsing.FunctionParser;
+import tools.DefaultFunctions;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NoEscapeTest {
+
+	@Test
+	void sinPi() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test = FunctionParser.parseInfix("pi (1+1)+sin(pi/2)");
+		assertEquals(7.3, test.evaluate(Map.of('x', 3.2)), .3);
+		Settings.enforceEscapes = temp;
+	}
+
+	@Test
+	void log() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test = FunctionParser.parseInfix("log(x)+log(1)");
+		assertEquals(1, test.evaluate(Map.of('x', 10.0)), .3);
+		Settings.enforceEscapes = temp;
+	}
+
+	@Test
+	void distributeTerms() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test1 = FunctionParser.parseInfix("sin(x)*(1+5x)");
+		GeneralFunction test2 = FunctionParser.parseInfix("sin(x)+5*x*sin(x)");
+		assertEquals(((Product)test1).distributeAll(), test2);
+		Settings.enforceEscapes = temp;
+	}
+
+	@Test
+	void exp() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test = FunctionParser.parseInfix("exp(ln(x))");
+		assertEquals(4, test.evaluate(Map.of('x', 4.0)), .01);
+		Settings.enforceEscapes = temp;
+	}
+
+	@Test
+	void simpleInverseLnAndExp() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test1 = FunctionParser.parseInfix("exp(ln(x))");
+		GeneralFunction test2 = FunctionParser.parseInfix("ln(exp(x))");
+		assertEquals(test1, test2);
+		Settings.enforceEscapes = temp;
+	}
+
+	@Test
+	void simpleInverseTrig() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test1 = FunctionParser.parseInfix("asin(sin(x))");
+		GeneralFunction test2 = FunctionParser.parseInfix("cos(acos(x))");
+		assertEquals(test1, test2);
+		Settings.enforceEscapes = temp;
+	}
+
+	@Test
+	void inverseChain() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test1 = FunctionParser.parseInfix("asin(acos(exp(ln(sec(asec(cos(sin(x))))))))");
+		assertEquals(DefaultFunctions.X, test1.simplify()); // this isn't actually correct based on ranges, so if you add that this will break
+		Settings.enforceEscapes = temp;
+	}
+
+	@Test
+	void expInverses() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test1 = FunctionParser.parseSimplified("ln(e^logb_e(exp(x)))");
+		assertEquals(DefaultFunctions.X, test1);
+		Settings.enforceEscapes = temp;
+	}
+
+	@Test
+	void logFOC() {
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
+		GeneralFunction test1 = FunctionParser.parseSimplified("log(100)");
+		assertEquals(DefaultFunctions.TWO, test1);
+		Settings.enforceEscapes = temp;
+	}
+}

--- a/tests/SimplifyTest.java
+++ b/tests/SimplifyTest.java
@@ -133,33 +133,33 @@ public class SimplifyTest {
 
     @Test
     void simpleInverseLnAndExp() {
-        GeneralFunction test1 = FunctionParser.parseInfix("exp(ln(x))");
-        GeneralFunction test2 = FunctionParser.parseInfix("ln(exp(x))");
+        GeneralFunction test1 = FunctionParser.parseInfix("\\exp(\\ln(x))");
+        GeneralFunction test2 = FunctionParser.parseInfix("\\ln(\\exp(x))");
         assertEquals(test1, test2);
     }
 
     @Test
     void simpleInverseTrig() {
-        GeneralFunction test1 = FunctionParser.parseInfix("asin(sin(x))");
-        GeneralFunction test2 = FunctionParser.parseInfix("cos(acos(x))");
+        GeneralFunction test1 = FunctionParser.parseInfix("\\asin(\\sin(x))");
+        GeneralFunction test2 = FunctionParser.parseInfix("\\cos(\\acos(x))");
         assertEquals(test1, test2);
     }
 
     @Test
     void inverseChain() {
-        GeneralFunction test1 = FunctionParser.parseInfix("asin(acos(exp(ln(sec(asec(cos(sin(x))))))))");
+        GeneralFunction test1 = FunctionParser.parseInfix("\\asin(\\acos(\\exp(\\ln(\\sec(\\asec(\\cos(\\sin(x))))))))");
         assertEquals(DefaultFunctions.X, test1.simplify()); // this isn't actually correct based on ranges, so if you add that this will break
     }
 
     @Test
     void expInverses() {
-        GeneralFunction test1 = FunctionParser.parseSimplified("ln(e^logb_e(exp(x)))");
+        GeneralFunction test1 = FunctionParser.parseSimplified("\\ln(e^\\logb_e(\\exp(x)))");
         assertEquals(DefaultFunctions.X, test1); // this isn't actually correct based on ranges, so if you add that this will break
     }
 
     @Test
     void logFOC() {
-        GeneralFunction test1 = FunctionParser.parseSimplified("log(100)");
+        GeneralFunction test1 = FunctionParser.parseSimplified("\\log(100)");
         assertEquals(DefaultFunctions.TWO, test1);
     }
 }


### PR DESCRIPTION
Creates a new test category for all things that are explicitly without LaTeX escapes, and escapes all other tests