### PR TITLE
Make parsing errors more descriptive

### DIFF
--- a/src/parsing/FunctionParser.java
+++ b/src/parsing/FunctionParser.java
@@ -6,10 +6,7 @@ import functions.special.Constant;
 import functions.special.Variable;
 import tools.ParsingTools;
 
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import static parsing.OperationMaps.*;
 
@@ -50,10 +47,14 @@ public class FunctionParser {
 			if (Constant.isSpecialConstant(token)) {
 				functionStack.push(new Constant(token));
 			} else if (binaryOperations.containsKey(token)) {
+				if (functionStack.size() < 2)
+					throw new NoSuchElementException("Tried to pop two elements for " + token + ", but not enough elements exist. Parsing: " + postfix + ". Current stack: " + functionStack + ".");
 				GeneralFunction a = functionStack.pop();
 				GeneralFunction b = functionStack.pop();
 				functionStack.push(binaryOperations.get(token).construct(b, a));
 			} else if (unitaryOperations.containsKey(token)) {
+				if (functionStack.size() < 1)
+					throw new NoSuchElementException("Tried to pop an element for " + token + ", but not the stack is empty. Parsing: " + postfix + ".");
 				GeneralFunction c = functionStack.pop();
 				functionStack.push(unitaryOperations.get(token).construct(c));
 			} else {
@@ -66,7 +67,7 @@ public class FunctionParser {
 		}
 
 		if (functionStack.size() != 1)
-			throw new IndexOutOfBoundsException("functionStack size is " + functionStack.size() + ", current stack is " + functionStack);
+			throw new IndexOutOfBoundsException("Stack has more than one function at end of parsing. Parsing: " + postfix + ". Current stack: " + functionStack + ".");
 
 		return functionStack.pop();
 	}

--- a/src/ui/CommandUI.java
+++ b/src/ui/CommandUI.java
@@ -35,8 +35,8 @@ public class CommandUI {
 				} catch (RuntimeException e) {
 					output(e);
 					if (e instanceof CommandNotFoundException) {
-						System.out.print("When parsing the input as a raw function, the following exception was thrown: ");
-						output(KeywordInterface.prev);
+						System.out.println("When parsing the input as a raw function, an exception was thrown. To see details, enter '_'.");
+//						output(KeywordInterface.prev);
 					}
 				}
 			}


### PR DESCRIPTION
This branch:
- rewrites most parser errors
- makes it so that stack pops are checked before execution so that an exception is preemptively thrown
- makes it so that parser errors are not immediately fed to the user and must be printed with `_`