### PR TITLE
GCD evaluation efficiency

### DIFF
--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -35,9 +35,7 @@ public class KeywordInterface {
 	 */
 	public static Object prev;
 
-	private KeywordInterface(){
-
-	}
+	private KeywordInterface(){}
 
 	/**
 	 * Takes input as a string in the format {@code "command arguments..."}

--- a/src/tools/MiscTools.java
+++ b/src/tools/MiscTools.java
@@ -40,7 +40,7 @@ public class MiscTools {
 	 * @return the GCD of the inputs
 	 */
 	public static int gcd(int a, int b) {
-		return a < b ? gcd(b, a) : b == 0 ? a : gcd(b, a % b);
+		return b == 0 ? a : gcd(b, a % b);
 	}
 
 	/**


### PR DESCRIPTION
This branch:
 - Removes an unnecessary ternary operator in the evaluation of GCD through MiscTools
 - Remove whitespace in the KeywordInterface private constructor