### PR TITLE
Change equals to equalsSimplified

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
  - Make parsing errors more descriptive
  - Port parsing to use operation maps rather than operation lists
  - Add new test class for integer operations
+ - Change `equals` to check if two functions are exactly equal and `equalsSimplified` to check if they are equal when simplified
  
  ### Bugfixes
  - Fix `toInteger` error message using the wrong margin from `Settings`

--- a/src/functions/GeneralFunction.java
+++ b/src/functions/GeneralFunction.java
@@ -136,10 +136,8 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 	 * @param that the object that this is compared against
 	 * @return true if they're equalsSimplified
 	 */
-	public boolean equalsSimplified(Object that) {
-		if (!(that instanceof GeneralFunction))
-			return false;
-		return this.simplify().equalsFunction(((GeneralFunction) that).simplify());
+	public boolean equalsSimplified(GeneralFunction that) {
+		return this.simplify().equalsFunction(that.simplify());
 	}
 
 	/**

--- a/src/functions/GeneralFunction.java
+++ b/src/functions/GeneralFunction.java
@@ -134,7 +134,7 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 	/**
 	 * Simplifies the two functions, then compares them with {@link #equalsFunction(GeneralFunction)}
 	 * @param that the object that this is compared against
-	 * @return true if they're equivalent
+	 * @return true if they're equalsSimplified
 	 */
 	public boolean equalsSimplified(Object that) {
 		if (!(that instanceof GeneralFunction))

--- a/src/functions/GeneralFunction.java
+++ b/src/functions/GeneralFunction.java
@@ -134,7 +134,7 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 	/**
 	 * Simplifies the two functions, then compares them with {@link #equalsFunction(GeneralFunction)}
 	 * @param that the object that this is compared against
-	 * @return true if they're equalsSimplified
+	 * @return true if they're equal when simplified
 	 */
 	public boolean equalsSimplified(GeneralFunction that) {
 		return this.simplify().equalsFunction(that.simplify());

--- a/src/functions/GeneralFunction.java
+++ b/src/functions/GeneralFunction.java
@@ -133,7 +133,7 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 
 	/**
 	 * Simplifies the two functions, then compares them with {@link #equalsFunction(GeneralFunction)}
-	 * @param that the object that this is compared against
+	 * @param that the function to be compared against
 	 * @return true if they're equal when simplified
 	 */
 	public boolean equalsSimplified(GeneralFunction that) {
@@ -142,7 +142,7 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 
 	/**
 	 * Compares two functions with {@link #equalsFunction(GeneralFunction)}
-	 * @param that the object that this is compared against
+	 * @param that the object to be compared against
 	 * @return true if they're equal
 	 */
 	public boolean equals(Object that) {

--- a/src/functions/GeneralFunction.java
+++ b/src/functions/GeneralFunction.java
@@ -134,12 +134,23 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 	/**
 	 * Simplifies the two functions, then compares them with {@link #equalsFunction(GeneralFunction)}
 	 * @param that the object that this is compared against
+	 * @return true if they're equivalent
+	 */
+	public boolean equalsSimplified(Object that) {
+		if (!(that instanceof GeneralFunction))
+			return false;
+		return this.simplify().equalsFunction(((GeneralFunction) that).simplify());
+	}
+
+	/**
+	 * Compares two functions with {@link #equalsFunction(GeneralFunction)}
+	 * @param that the object that this is compared against
 	 * @return true if they're equal
 	 */
 	public boolean equals(Object that) {
 		if (!(that instanceof GeneralFunction))
 			return false;
-		return this.simplify().equalsFunction(((GeneralFunction) that).simplify());
+		return this.equalsFunction((GeneralFunction) that);
 	}
 
 	/**

--- a/src/functions/binary/Logb.java
+++ b/src/functions/binary/Logb.java
@@ -68,7 +68,7 @@ public class Logb extends BinaryFunction {
 	 * @return {@link DefaultFunctions#ONE} if the base of the logarithm equals the argument
 	 */
 	public GeneralFunction simplifyIdentity() {
-		if (function2.equals(function1))
+		if (function2.equalsSimplified(function1))
 			return DefaultFunctions.ONE;
 		else
 			return this;

--- a/src/functions/binary/Pow.java
+++ b/src/functions/binary/Pow.java
@@ -137,7 +137,7 @@ public class Pow extends BinaryFunction {
 	 * @return the argument of the logarithm in the exponent, if the exponent is a logarithm with the same base as the {@link Pow}
 	 */
 	public GeneralFunction simplifyLogsOfSameBase() {
-		if (function1 instanceof Logb logb && logb.getFunction2().equals(function2))
+		if (function1 instanceof Logb logb && logb.getFunction2().equalsSimplified(function2))
 			return logb.getFunction1();
 		else if (function1 instanceof Ln ln && function2 instanceof Constant constant && constant.constant == Math.E)
 			return ln.operand;

--- a/src/functions/commutative/CommutativeFunction.java
+++ b/src/functions/commutative/CommutativeFunction.java
@@ -3,6 +3,7 @@ package functions.commutative;
 import functions.GeneralFunction;
 import functions.special.Constant;
 import org.jetbrains.annotations.NotNull;
+import tools.ArrayTools;
 
 import java.util.*;
 import java.util.function.Function;
@@ -44,7 +45,7 @@ public abstract class CommutativeFunction extends GeneralFunction {
 
 	public boolean equalsFunction(GeneralFunction that) {
 		if (that instanceof CommutativeFunction function && this.getClass().equals(that.getClass()))
-			return Arrays.equals(functions, function.getFunctions());
+			return ArrayTools.equalsSimplified(functions, function.getFunctions());
 		else
 			return false;
 	}

--- a/src/functions/unitary/specialcases/Ln.java
+++ b/src/functions/unitary/specialcases/Ln.java
@@ -46,7 +46,7 @@ public class Ln extends SpecialCaseBinaryFunction {
 	@Override
 	public GeneralFunction simplifyInverse() {
 		if (operand instanceof Pow pow)
-			return new Product(pow.getFunction1(), new Ln(pow.getFunction2()));
+			return new Product(pow.getFunction1(), new Ln(pow.getFunction2())).simplify();
 		else
 			return super.simplifyInverse();
 	}

--- a/src/functions/unitary/transforms/Differential.java
+++ b/src/functions/unitary/transforms/Differential.java
@@ -49,7 +49,7 @@ public class Differential extends Transformation {
 	@Override
 	public boolean equalsFunction(GeneralFunction that) {
 		if (that instanceof Differential diff)
-			return respectTo == diff.respectTo && operand.equals(diff.operand);
+			return respectTo == diff.respectTo && operand.equalsSimplified(diff.operand);
 		else
 			return false;
 	}

--- a/src/functions/unitary/transforms/Integral.java
+++ b/src/functions/unitary/transforms/Integral.java
@@ -54,7 +54,7 @@ public class Integral extends Transformation {
 	@Override
 	public boolean equalsFunction(GeneralFunction that) {
 		if (that instanceof Integral integral)
-			return respectTo == integral.respectTo && operand.equals(integral.operand);
+			return respectTo == integral.respectTo && operand.equalsSimplified(integral.operand);
 		else
 			return false;
 	}

--- a/src/functions/unitary/transforms/PartialDerivative.java
+++ b/src/functions/unitary/transforms/PartialDerivative.java
@@ -38,7 +38,7 @@ public class PartialDerivative extends Transformation {
 	@Override
 	public boolean equalsFunction(GeneralFunction that) {
 		if (that instanceof PartialDerivative pd)
-			return respectTo == pd.respectTo && operand.equals(pd.operand);
+			return respectTo == pd.respectTo && operand.equalsSimplified(pd.operand);
 		else
 			return false;
 	}

--- a/src/parsing/OperationMaps.java
+++ b/src/parsing/OperationMaps.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 /**
  * {@link OperationMaps} is a centralized location for the strings of all unitary and binary operations to be stored for parsing.
- * The conversions between these strings and their {@link functions.GeneralFunction} equivalents are stored as lambdas in their respective maps.
+ * The conversions between these strings and their {@link functions.GeneralFunction} equalsSimplifieds are stored as lambdas in their respective maps.
  */
 public class OperationMaps {
 

--- a/src/tools/ArrayTools.java
+++ b/src/tools/ArrayTools.java
@@ -63,4 +63,14 @@ public class ArrayTools {
 		return finalFunctionArray;
 	}
 
+
+	public static boolean equalsSimplified(GeneralFunction[] first, GeneralFunction[] second) {
+		if (first.length != second.length)
+			return false;
+		for (int i = 0; i < first.length; i++)
+			if (!first[i].equalsSimplified(second[i]))
+				return false;
+		return true;
+	}
+
 }

--- a/src/tools/integration/StageOne.java
+++ b/src/tools/integration/StageOne.java
@@ -140,7 +140,7 @@ public class StageOne {
         GeneralFunction derivativeWithoutConstant = derivative.getSecond();
         GeneralFunction constantInFront = derivative.getFirst();
         Product derivativeTimesOperation = new Product(derivativeWithoutConstant, term);
-        if (!SearchTools.existsInSurfaceSubset(product, derivativeTimesOperation::equals) || SearchTools.existsInOppositeSurfaceSubset(product, (u -> SearchTools.existsAny(u, VariableTools.isVariable(variableChar))), derivativeTimesOperation::equals))
+        if (!SearchTools.existsInSurfaceSubset(product, derivativeTimesOperation::equalsSimplified) || SearchTools.existsInOppositeSurfaceSubset(product, (u -> SearchTools.existsAny(u, VariableTools.isVariable(variableChar))), derivativeTimesOperation::equalsSimplified))
             return null;
         else
             return constantInFront;

--- a/tests/EqualsTest.java
+++ b/tests/EqualsTest.java
@@ -11,7 +11,7 @@ public class EqualsTest {
     void unitaryEqualsUnitary() {
         GeneralFunction test1 = FunctionParser.parseInfix("\\sin(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("\\sin(x)");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
@@ -46,77 +46,77 @@ public class EqualsTest {
     void switchedOrderVariableConstant() {
         GeneralFunction test1 = FunctionParser.parseInfix("1+2x");
         GeneralFunction test2 = FunctionParser.parseInfix("2x+1");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedOrderVariables() {
         GeneralFunction test1 = FunctionParser.parseInfix("x+y");
         GeneralFunction test2 = FunctionParser.parseInfix("y + x");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedVariablesWithPowers() {
         GeneralFunction test1 = FunctionParser.parseInfix("x^2+x^3");
         GeneralFunction test2 = FunctionParser.parseInfix("x^3+x^2");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedOrderVariableMultiply() {
         GeneralFunction test1 = FunctionParser.parseInfix("x+2y");
         GeneralFunction test2 = FunctionParser.parseInfix("2y + x");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedOrderMultiplies() {
         GeneralFunction test1 = FunctionParser.parseInfix("3x+2y");
         GeneralFunction test2 = FunctionParser.parseInfix("2y + 3x");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedOrderVariablesMul() {
         GeneralFunction test1 = FunctionParser.parseInfix("x*y");
         GeneralFunction test2 = FunctionParser.parseInfix("yx");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedVariablesWithPowersMul() {
         GeneralFunction test1 = FunctionParser.parseInfix("x^2*x^3");
         GeneralFunction test2 = FunctionParser.parseInfix("x^3*x^2");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedOrderVariableMultiplyMul() {
         GeneralFunction test1 = FunctionParser.parseInfix("x*2*y");
         GeneralFunction test2 = FunctionParser.parseInfix("2*y*x");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedOrderMultipliesMul() {
         GeneralFunction test1 = FunctionParser.parseInfix("3x*2y");
         GeneralFunction test2 = FunctionParser.parseInfix("2y*3x");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedOrderComplicated() {
         GeneralFunction test1 = FunctionParser.parseInfix("x^2+1+y+3\\sin(x)+2x");
         GeneralFunction test2 = FunctionParser.parseInfix("3(\\sin(x))+y+x^2+2x+1");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void switchedOrderTrig() {
         GeneralFunction test1 = FunctionParser.parseInfix("\\sin(x)+\\cos(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("\\cos(x)+\\sin(x)");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
 }

--- a/tests/IntegerTest.java
+++ b/tests/IntegerTest.java
@@ -45,14 +45,14 @@ public class IntegerTest {
 
     @Test
     void gcd() {
-        assertEquals(new Constant(4), new GCD(new Constant(4), new Constant(196), new Constant(80)));
+        assertEquals(new Constant(4), new GCD(new Constant(4), new Constant(196), new Constant(80)).simplify());
         assertEquals(4, new GCD(new Constant(4), new Constant(196), new Constant(80)).evaluate(Map.of()));
     }
 
 
     @Test
     void lcm() {
-        assertEquals(new Constant(3920), new LCM(new Constant(4), new Constant(196), new Constant(80)));
+        assertEquals(new Constant(3920), new LCM(new Constant(4), new Constant(196), new Constant(80)).simplify());
         assertEquals(3920, new LCM(new Constant(4), new Constant(196), new Constant(80)).evaluate(Map.of()));
     }
 

--- a/tests/IntegralTest.java
+++ b/tests/IntegralTest.java
@@ -16,156 +16,156 @@ public class IntegralTest {
 
     @Test
     void splitAdds() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("x+e^x"), 'x');
-        GeneralFunction test2 = new Sum(FunctionParser.parseInfix("0.5*x^2"), FunctionParser.parseInfix("e^x"));
-        assertEquals(test1.execute(), test2);
+        Integral test1 = new Integral(FunctionParser.parseSimplified("x+e^x"), 'x');
+        GeneralFunction test2 = new Sum(FunctionParser.parseSimplified("0.5*x^2"), FunctionParser.parseSimplified("e^x"));
+        assertEquals(test1.execute().simplify(), test2);
     }
 
     @Test
     void unwrapsExponents() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("(x^2+2)^2"), 'x');
-        GeneralFunction test2 = new Sum(FunctionParser.parseInfix("(x^5)/5"), FunctionParser.parseInfix("4/3*x^3"), FunctionParser.parseInfix("4x"));
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("(x^2+2)^2"), 'x');
+        GeneralFunction test2 = new Sum(FunctionParser.parseSimplified("(x^5)/5"), FunctionParser.parseSimplified("4/3*x^3"), FunctionParser.parseSimplified("4x"));
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void stripConstantsSimple() {
-        GeneralFunction test1 = FunctionParser.parseInfix("3\\sin(x)");
+        GeneralFunction test1 = FunctionParser.parseSimplified("3\\sin(x)");
         Pair<GeneralFunction, GeneralFunction> test2 = IntegralTools.stripConstantsRespectTo(test1, 'x');
         assertEquals(new Constant(3), test2.getFirst());
-        assertEquals(FunctionParser.parseInfix("\\sin(x)"), test2.getSecond());
+        assertEquals(FunctionParser.parseSimplified("\\sin(x)"), test2.getSecond());
     }
 
     @Test
     void simpleExponentIntegral() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("e^x"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("e^x");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("e^x"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("e^x");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simpleExponentIntegralWithConstant() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("2e^x"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("2e^x");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("2e^x"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("2e^x");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simpleExponentIntegralWithLinerTermInExponent() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("2e^(2x-3)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("e^(2x-3)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("2e^(2x-3)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("e^(2x-3)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simplePowers() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("x^2"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("1/3 * x^3");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("x^2"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("1/3 * x^3");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simpleTrig() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("\\cos(x)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("\\sin(x)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("\\cos(x)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("\\sin(x)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simpleTrigWithConstants() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("4*\\cos(2x+3)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("2*\\sin(2x+3)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("4*\\cos(2x+3)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("2*\\sin(2x+3)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simpleReciprocal() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("e^x/(1+e^x)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("\\ln(1+e^x)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("e^x/(1+e^x)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("\\ln(1+e^x)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simpleSquareRoot() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("x*\\sqrt(1+x^2)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("1/3 * (1+x^2)^(3/2)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("x*\\sqrt(1+x^2)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("1/3 * (1+x^2)^(3/2)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simpleExpUSub() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("x*e^(x^2)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("1/2*e^(x^2)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("x*e^(x^2)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("1/2*e^(x^2)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void simpleExpUSubThatNoWork() {
-        Integral test1 = new Integral(FunctionParser.parseInfix("2x*\\sin(x)*e^(x^2)"), 'x');
+        Integral test1 = new Integral(FunctionParser.parseSimplified("2x*\\sin(x)*e^(x^2)"), 'x');
         assertThrows(IntegrationFailedException.class, test1::execute);
     }
 
     @Test
     void simpleOPIsOne() throws Exception {
-        GeneralFunction test1 = new Integral(FunctionParser.parseInfix("\\cos(x)*\\sin(x)"), 'x').execute();
-        GeneralFunction test2 = FunctionParser.parseInfix("1/2*(\\sin(x))^2");
-        GeneralFunction test3 = FunctionParser.parseInfix("-1/2*(\\cos(x))^2");
+        GeneralFunction test1 = new Integral(FunctionParser.parseSimplified("\\cos(x)*\\sin(x)"), 'x').execute().simplify();
+        GeneralFunction test2 = FunctionParser.parseSimplified("1/2*(\\sin(x))^2");
+        GeneralFunction test3 = FunctionParser.parseSimplified("-1/2*(\\cos(x))^2");
         assertTrue(test1.equals(test2) || test1.equals(test3));
     }
 
     @Test
     void complexUSub() throws Exception {
         Integral test1 = new Integral(FunctionParser.parseInfix("(\\cos(e^x))^2*\\sin(e^x)*e^x"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("-1/3*(\\cos(e^x))^3");
-        assertEquals(test2, test1.execute());
+        GeneralFunction test2 = FunctionParser.parseSimplified("-1/3*(\\cos(e^x))^3");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void severalVariableBasic() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("x^y"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("1/(y+1)*x^(y+1)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("x^y"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("1/(y+1)*x^(y+1)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void severalVariableBasicWithoutX() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("y*z^y*\\ln(y)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("y*z^y*\\ln(y)*x");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("y*z^y*\\ln(y)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("y*z^y*\\ln(y)*x");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void severalVariableBasicWithX() throws Exception {
         Integral test1 = new Integral(FunctionParser.parseSimplified("y*z^y*\\ln(y)x^3"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("y*z^y*\\ln(y)*x^4/4");
-        assertEquals(test2, test1.execute());
+        GeneralFunction test2 = FunctionParser.parseSimplified("y*z^y*\\ln(y)*x^4/4");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void severalVariableBasicWithXUnsimplified() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("y*z^y*\\ln(y)x^3"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("y*z^y*\\ln(y)*x^4/4");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("y*z^y*\\ln(y)x^3"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("y*z^y*\\ln(y)*x^4/4");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void severalVariableBasicFunctionOfXAndY1() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("e^(3x+y)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("1/3*e^(3x+y)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("e^(3x+y)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("1/3*e^(3x+y)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void severalVariableBasicFunctionOfXAndY2() throws Exception {
-        Integral test1 = new Integral(FunctionParser.parseInfix("e^(3xy+y)"), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("1/(3y)*e^(3xy+y)");
-        assertEquals(test2, test1.execute());
+        Integral test1 = new Integral(FunctionParser.parseSimplified("e^(3xy+y)"), 'x');
+        GeneralFunction test2 = FunctionParser.parseSimplified("1/(3y)*e^(3xy+y)");
+        assertEquals(test2, test1.execute().simplify());
     }
 
     @Test
     void noIntegrand() throws Exception {
         Integral test1 = new Integral(new Product(), 'x');
-        GeneralFunction test2 = FunctionParser.parseInfix("x");
-        assertEquals(test2, test1.execute());
+        GeneralFunction test2 = FunctionParser.parseSimplified("x");
+        assertEquals(test2, test1.execute().simplify());
     }
 }

--- a/tests/KeywordInterfaceTest.java
+++ b/tests/KeywordInterfaceTest.java
@@ -16,35 +16,35 @@ public class KeywordInterfaceTest {
     void partialDerivatives() {
         GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("pd x x^2");
         GeneralFunction test2 = FunctionParser.parseInfix("2x");
-        assertEquals(test2, test1);
+        assertEquals(test2.simplify(), test1);
     }
 
     @Test
     void doublePartialDerivatives() {
         GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("pd x pd x x^2");
         GeneralFunction test2 = FunctionParser.parseInfix("2");
-        assertEquals(test2, test1);
+        assertEquals(test2.simplify(), test1);
     }
 
     @Test
     void partialWithRespectToVariableDoesNotExist() {
         GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("pd n x^2");
         GeneralFunction test2 = FunctionParser.parseInfix("0");
-        assertEquals(test2, test1);
+        assertEquals(test2.simplify(), test1);
     }
 
     @Test
     void partialOfASimp() {
         GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("pd x simp 2x+3x");
         GeneralFunction test2 = FunctionParser.parseInfix("5");
-        assertEquals(test2, test1);
+        assertEquals(test2.simplify(), test1);
     }
 
     @Test
     void partialDerivativeNTimes() {
         GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("pdn x 4 \\sin(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("\\sin(x)");
-        assertEquals(test2, test1);
+        assertEquals(test2.simplify(), test1);
     }
 
     @Test
@@ -74,7 +74,7 @@ public class KeywordInterfaceTest {
     void basicSimplify() {
         GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("simp 1*(x+2x+0)");
         GeneralFunction test2 = FunctionParser.parseInfix("3x");
-        assertEquals(test2, test1);
+        assertEquals(test2.simplify(), test1);
     }
 
     @Test
@@ -82,7 +82,7 @@ public class KeywordInterfaceTest {
         KeywordInterface.useKeywords("def t x^2");
         GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("sa sub z+y y t");
         GeneralFunction test2 = FunctionParser.parseInfix("z+x^2");
-        assertEquals(test2, test1);
+        assertEquals(test2.simplify(), test1);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class KeywordInterfaceTest {
     void basicTaylor() {
         GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("tay \\cos(x) 1 0");
         GeneralFunction test2 = FunctionParser.parseInfix("1");
-        assertEquals(test2, test1);
+        assertEquals(test2.simplify(), test1);
     }
 
     @Test

--- a/tests/NoEscapeTest.java
+++ b/tests/NoEscapeTest.java
@@ -54,7 +54,7 @@ public class NoEscapeTest {
 		Settings.enforceEscapes = false;
 		GeneralFunction test1 = FunctionParser.parseInfix("exp(ln(x))");
 		GeneralFunction test2 = FunctionParser.parseInfix("ln(exp(x))");
-		assertEquals(test1, test2);
+		assertEquals(test1.simplify(), test2.simplify());
 		Settings.enforceEscapes = temp;
 	}
 
@@ -64,7 +64,7 @@ public class NoEscapeTest {
 		Settings.enforceEscapes = false;
 		GeneralFunction test1 = FunctionParser.parseInfix("asin(sin(x))");
 		GeneralFunction test2 = FunctionParser.parseInfix("cos(acos(x))");
-		assertEquals(test1, test2);
+		assertEquals(test1.simplify(), test2.simplify());
 		Settings.enforceEscapes = temp;
 	}
 

--- a/tests/SimplifyTest.java
+++ b/tests/SimplifyTest.java
@@ -15,7 +15,7 @@ public class SimplifyTest {
     void equalWhenSimplified() {
         GeneralFunction test1 = FunctionParser.parseInfix("x+(1+3-2)*1");
         GeneralFunction test2 = FunctionParser.parseInfix("x+2");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
@@ -23,27 +23,27 @@ public class SimplifyTest {
         GeneralFunction test1, test2;
         test1 = FunctionParser.parseInfix("1");
         test2 = FunctionParser.parseInfix("0+1");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
         test1 = FunctionParser.parseInfix("1");
         test2 = FunctionParser.parseInfix("2");
         assertNotEquals(test1, test2);
         test1 = FunctionParser.parseInfix("e");
         test2 = FunctionParser.parseInfix("" + Math.E);
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void simplifiesDivisionExponents() {
         GeneralFunction test1 = FunctionParser.parseInfix("x^3/x^2");
         GeneralFunction test2 = FunctionParser.parseInfix("x");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void combineLikeTerms() {
         GeneralFunction test1 = FunctionParser.parseInfix("3*x^2+5*x^-1+7*x^-1-3*x^2+1");
         GeneralFunction test2 = FunctionParser.parseInfix("1+12*x^-1");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
@@ -58,91 +58,91 @@ public class SimplifyTest {
         Settings.distributeExponents = true;
         GeneralFunction test1 = FunctionParser.parseInfix("(2xy)^2");
         GeneralFunction test2 = FunctionParser.parseInfix("4x^2y^2");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void addExponents() {
         GeneralFunction test1 = FunctionParser.parseInfix("x^2*x^4");
         GeneralFunction test2 = FunctionParser.parseInfix("x^6");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void combineLikeTermsMultExample() {
         GeneralFunction test1 = FunctionParser.parseInfix("(3+x)(2+x)(1+x)");
         GeneralFunction test2 = FunctionParser.parseInfix("x^3+11x+6x^2+6");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void simplifySimpleExponents() {
         GeneralFunction test1 = FunctionParser.parseInfix("(x+1)^1");
         GeneralFunction test2 = FunctionParser.parseInfix("x+1");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void simplifyMultiplyExponents() {
         GeneralFunction test1 = FunctionParser.parseInfix("(x^3)^2");
         GeneralFunction test2 = FunctionParser.parseInfix("x^6");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void simplifyIdentity() {
         GeneralFunction test1 = FunctionParser.parseInfix("x+0");
         GeneralFunction test2 = FunctionParser.parseInfix("x*1");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void simplifyPullAdd() {
         GeneralFunction test1 = FunctionParser.parseInfix("(x+(y+z))");
         GeneralFunction test2 = FunctionParser.parseInfix("x+y+z");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void simplifyPullMultiply() {
         GeneralFunction test1 = FunctionParser.parseInfix("x*(yz)");
         GeneralFunction test2 = FunctionParser.parseInfix("x*y*z");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void timesZero() {
         GeneralFunction test1 = FunctionParser.parseInfix("x*0");
         GeneralFunction test2 = FunctionParser.parseInfix("0");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void unwrapPowersTest() {
         GeneralFunction test1 = FunctionParser.parseInfix("(x+1)^3");
         GeneralFunction test2 = FunctionParser.parseInfix("(x+1)*(x+1)*(x+1)");
-        assertEquals(((Pow)test1).unwrapIntegerPowerSafe(), test2);
+        assertEquals(((Pow) test1).unwrapIntegerPowerSafe().simplify(), test2.simplify());
     }
 
     @Test
     void unwrapPowersEdgeTest() {
         GeneralFunction test1 = FunctionParser.parseInfix("(x+1)^0");
         GeneralFunction test2 = FunctionParser.parseInfix("1");
-        assertEquals(((Pow)test1).unwrapIntegerPowerSafe(), test2);
+        assertEquals(((Pow) test1).unwrapIntegerPowerSafe().simplify(), test2);
     }
 
     @Test
     void simpleInverseLnAndExp() {
         GeneralFunction test1 = FunctionParser.parseInfix("\\exp(\\ln(x))");
         GeneralFunction test2 = FunctionParser.parseInfix("\\ln(\\exp(x))");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test
     void simpleInverseTrig() {
         GeneralFunction test1 = FunctionParser.parseInfix("\\asin(\\sin(x))");
         GeneralFunction test2 = FunctionParser.parseInfix("\\cos(\\acos(x))");
-        assertEquals(test1, test2);
+        assertEquals(test1.simplify(), test2.simplify());
     }
 
     @Test


### PR DESCRIPTION
The current implementation of `equals` is misleading as it checks if two functions are equivalent, not equal. This branch remedies this by renaming the current implementation of `equals` to `equalsSimplified`. In addition, this branch:
 - Fixes a bad simplification in `Ln.simplifyInverse`
 - Implements ArrayTools.equalsSimplified