### PR TITLE
Integer function errors 2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,8 @@
  
  ### Bugfixes
  - Fix `toInteger` error message using the wrong margin from `Settings`
-
+ - Fix bad rounding in `ParsingTools.toInteger` and `ParsingTools.isAlmostInteger`
+ 
 ## v0.1.2
 ### Bugfixes
  - Fix properties not being read on launch for binaries

--- a/src/functions/binary/integer/IntegerBinaryFunction.java
+++ b/src/functions/binary/integer/IntegerBinaryFunction.java
@@ -39,7 +39,7 @@ public abstract class IntegerBinaryFunction extends BinaryFunction {
 		double a = function1.evaluate(variableValues);
 		double b = function2.evaluate(variableValues);
 		if (!ParsingTools.isAlmostInteger(a) || !ParsingTools.isAlmostInteger(b))
-			throw new IllegalArgumentException("Tried to evaluate an IntegerUnitaryFunction with non-integer operand set " + a + ", " + b);
+			throw new IllegalArgumentException("Tried to evaluate an IntegerBinaryFunction with non-integer operand set " + a + ", " + b);
 		return operate(ParsingTools.toInteger(b), ParsingTools.toInteger(a));
 	}
 

--- a/src/tools/ParsingTools.java
+++ b/src/tools/ParsingTools.java
@@ -81,7 +81,7 @@ public class ParsingTools {
 	 * @return true if the {@code double} is within {@link Settings#integerMargin} of an integer
 	 */
 	public static boolean isAlmostInteger(double d) throws IllegalArgumentException{
-		return Math.abs(((int) (d + .5)) - d) < Settings.integerMargin;
+		return Math.abs(Math.round(d) - d) < Settings.integerMargin;
 	}
 
 	/**

--- a/src/tools/ParsingTools.java
+++ b/src/tools/ParsingTools.java
@@ -70,7 +70,7 @@ public class ParsingTools {
 	 */
 	public static int toInteger(double d) throws IllegalArgumentException{
 		if (isAlmostInteger(d))
-			return (int) (d + .5);
+			return (int) Math.round(d);
 		else
 			throw new IllegalArgumentException("Double " + d + " is not within " + Settings.integerMargin + " of an integer.");
 	}


### PR DESCRIPTION
Fixes:
 - Error in `IntegerBinaryFunctions` using incorrect classname
 - Bad rounding in `ParsingTools.toInteger` and `ParsingTools.isAlmostInteger`
This time, without the extra stuff that wasn't supposed to be pushed.