### PR TITLE
Make KeywordInterface substitute more powerful and fix setVariables removal

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
  - Add new test class for integer operations
  - Change `equals` to check if two functions are exactly equal and implement `equalsSimplified` to check if they are equal when simplified
  - Add `DerivativeDoesNotExistException` for operations with no derivative
+ - Make `substitute` more powerful in the UI by allowing the substitution of multiple expressions simultaneously
  
  ### Bugfixes
  - Fix `toInteger` error message using the wrong margin from `Settings`

--- a/src/functions/GeneralFunction.java
+++ b/src/functions/GeneralFunction.java
@@ -106,13 +106,12 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 	public abstract GeneralFunction substituteAll(Predicate<? super GeneralFunction> test, Function<? super GeneralFunction, ? extends GeneralFunction> replacer);
 
 	/**
-	 * Substitutes a new {@link GeneralFunction} into a {@link Variable}
-	 * @param varID     the variable to be substituted into
-	 * @param toReplace the {@link GeneralFunction} that will be substituted
+	 * Substitutes variables with functions as specified in a map
+	 * @param toSubstitute the map between {@link Variable} strings and {@link GeneralFunction}s
 	 * @return the new {@link GeneralFunction} after all substitutions are preformed
 	 */
-	public GeneralFunction substituteVariable(String varID, GeneralFunction toReplace) {
-		return substituteAll(f -> (f instanceof Variable v && v.varID.equals(varID)), f -> toReplace);
+	public GeneralFunction substituteVariable(Map<String, ? extends GeneralFunction> toSubstitute) {
+		return substituteAll(f -> (f instanceof Variable v && toSubstitute.containsKey(v.varID)), f -> toSubstitute.get(((Variable) f).varID));
 	}
 
 	/**
@@ -121,10 +120,13 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 	 * @return a new function with the substitutions made
 	 */
 	public GeneralFunction setVariables(Map<String, Double> values) {
-		GeneralFunction current = this;
-		for (Map.Entry<String, Double> entry : values.entrySet())
-			current = current.substituteVariable(entry.getKey(), new Constant(entry.getValue()));
-		return current;
+		//noinspection unchecked
+		return substituteVariable(
+				Map.ofEntries(values.entrySet().stream()
+						.map(e -> Map.entry(e.getKey(), new Constant(e.getValue())))
+						.toArray(Map.Entry[]::new)
+				)
+		);
 	}
 
 

--- a/src/functions/GeneralFunction.java
+++ b/src/functions/GeneralFunction.java
@@ -110,7 +110,7 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 	 * @param toSubstitute the map between {@link Variable} strings and {@link GeneralFunction}s
 	 * @return the new {@link GeneralFunction} after all substitutions are preformed
 	 */
-	public GeneralFunction substituteVariable(Map<String, ? extends GeneralFunction> toSubstitute) {
+	public GeneralFunction substituteVariables(Map<String, ? extends GeneralFunction> toSubstitute) {
 		return substituteAll(f -> (f instanceof Variable v && toSubstitute.containsKey(v.varID)), f -> toSubstitute.get(((Variable) f).varID));
 	}
 
@@ -121,7 +121,7 @@ public abstract class GeneralFunction implements Evaluable, Differentiable, Simp
 	 */
 	public GeneralFunction setVariables(Map<String, Double> values) {
 		//noinspection unchecked
-		return substituteVariable(
+		return substituteVariables(
 				Map.ofEntries(values.entrySet().stream()
 						.map(e -> Map.entry(e.getKey(), new Constant(e.getValue())))
 						.toArray(Map.Entry[]::new)

--- a/src/functions/unitary/transforms/Differential.java
+++ b/src/functions/unitary/transforms/Differential.java
@@ -51,8 +51,8 @@ public class Differential extends Transformation {
 	}
 
 	@Override
-	public GeneralFunction substituteVariable(String varID, GeneralFunction toReplace) {
-		if (varID.equals(respectTo))
+	public GeneralFunction substituteVariable(Map<String, ? extends GeneralFunction> toSubstitute) {
+		if (toSubstitute.containsKey(respectTo))
 			throw new UnsupportedOperationException("You cannot substitute the variable you are working with respect to");
 		return this;
 	}

--- a/src/functions/unitary/transforms/Differential.java
+++ b/src/functions/unitary/transforms/Differential.java
@@ -51,7 +51,7 @@ public class Differential extends Transformation {
 	}
 
 	@Override
-	public GeneralFunction substituteVariable(Map<String, ? extends GeneralFunction> toSubstitute) {
+	public GeneralFunction substituteVariables(Map<String, ? extends GeneralFunction> toSubstitute) {
 		if (toSubstitute.containsKey(respectTo))
 			throw new UnsupportedOperationException("You cannot substitute the variable you are working with respect to");
 		return this;

--- a/src/functions/unitary/transforms/Integral.java
+++ b/src/functions/unitary/transforms/Integral.java
@@ -45,10 +45,10 @@ public class Integral extends Transformation {
 	}
 
 	@Override
-	public GeneralFunction substituteVariable(String varID, GeneralFunction toReplace) {
-		if (varID.equals(respectTo))
+	public GeneralFunction substituteVariable(Map<String, ? extends GeneralFunction> toSubstitute) {
+		if (toSubstitute.containsKey(respectTo))
 			throw new UnsupportedOperationException("You cannot substitute the variable you are working with respect to");
-		return new Integral(operand.substituteVariable(varID, toReplace), respectTo);
+		return new Integral(operand.substituteVariable(toSubstitute), respectTo);
 	}
 
 	@Override

--- a/src/functions/unitary/transforms/Integral.java
+++ b/src/functions/unitary/transforms/Integral.java
@@ -45,10 +45,10 @@ public class Integral extends Transformation {
 	}
 
 	@Override
-	public GeneralFunction substituteVariable(Map<String, ? extends GeneralFunction> toSubstitute) {
+	public GeneralFunction substituteVariables(Map<String, ? extends GeneralFunction> toSubstitute) {
 		if (toSubstitute.containsKey(respectTo))
 			throw new UnsupportedOperationException("You cannot substitute the variable you are working with respect to");
-		return new Integral(operand.substituteVariable(toSubstitute), respectTo);
+		return new Integral(operand.substituteVariables(toSubstitute), respectTo);
 	}
 
 	@Override

--- a/src/functions/unitary/transforms/PartialDerivative.java
+++ b/src/functions/unitary/transforms/PartialDerivative.java
@@ -28,11 +28,12 @@ public class PartialDerivative extends Transformation {
 		return new PartialDerivative(operand.clone(), respectTo);
 	}
 
+	
 	@Override
-	public GeneralFunction substituteVariable(String varID, GeneralFunction toReplace) {
-		if (varID.equals(respectTo))
+	public GeneralFunction substituteVariable(Map<String, ? extends GeneralFunction> toSubstitute) {
+		if (toSubstitute.containsKey(respectTo))
 			throw new UnsupportedOperationException("You cannot substitute the variable you are working with respect to");
-		return new PartialDerivative(operand.substituteVariable(varID, toReplace), respectTo);
+		return new PartialDerivative(operand.substituteVariable(toSubstitute), respectTo);
 	}
 
 	@Override

--- a/src/functions/unitary/transforms/PartialDerivative.java
+++ b/src/functions/unitary/transforms/PartialDerivative.java
@@ -30,10 +30,10 @@ public class PartialDerivative extends Transformation {
 
 	
 	@Override
-	public GeneralFunction substituteVariable(Map<String, ? extends GeneralFunction> toSubstitute) {
+	public GeneralFunction substituteVariables(Map<String, ? extends GeneralFunction> toSubstitute) {
 		if (toSubstitute.containsKey(respectTo))
 			throw new UnsupportedOperationException("You cannot substitute the variable you are working with respect to");
-		return new PartialDerivative(operand.substituteVariable(toSubstitute), respectTo);
+		return new PartialDerivative(operand.substituteVariables(toSubstitute), respectTo);
 	}
 
 	@Override

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -337,13 +337,13 @@ public class KeywordInterface {
 			case "pdn", "pdiffn", "partialn", "pdifferentiaten"         			-> "Executes 'pd' [times] times.\n" +
 					"pdn [variable] [times] [function]";
 			case "eval", "evaluate"                                     			-> "Evaluates [function] at the values specified.\n" +
-					"eval [function] (var=val)*";
+					"eval [function] ([variable]=[value]])*";
 			case "simp", "simplify"                                     			-> "Simplifies [function].\n" +
 					"simp [function]";
 			case "sub", "substitute"                                    			-> "Substitutes [replacementfunction] into every instance of [variable] in [function].\n" +
-					"sub [function] [variable] [replacementfunction]";
+					"sub [function] ([variable]=[replacementfunction])+";
 			case "subs", "substitutesimplify"                                    	-> "Substitutes [replacementfunction] into every instance of [variable] in [function] and then simplifies.\n" +
-					"subs [function] [variable] [replacementfunction]";
+					"subs [function] ([variable]=[replacementfunction])+";
 			case "sa", "suball"														-> "Substites every pre-defined function into [function] in accordance with its name.\n" +
 					"sa [function]";
 			case "sol", "solve"                                         			-> "Solves [function] in one variable on a range.\n" +

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -148,7 +148,7 @@ public class KeywordInterface {
 	 */
 	public static GeneralFunction substituteAll(GeneralFunction function) {
 		//noinspection unchecked
-		return function.substituteVariable(
+		return function.substituteVariables(
 					Map.ofEntries(storedFunctions.entrySet().stream()
 							.map(e -> Map.entry(LatexReplacer.encodeAll(e.getKey()), e.getValue()))
 							.toArray(Map.Entry[]::new)
@@ -199,7 +199,7 @@ public class KeywordInterface {
 
 	private static GeneralFunction substitute(String input) {
 		String[] splitInput = keywordSplitter.split(input, 2);
-		return parseStored(splitInput[0]).substituteVariable(Arrays.stream(keywordSplitter.split(splitInput[1])).map(equals::split).collect(Collectors.toMap(e -> e[0], e -> parseStored(e[1]))));
+		return parseStored(splitInput[0]).substituteVariables(Arrays.stream(keywordSplitter.split(splitInput[1])).map(equals::split).collect(Collectors.toMap(e -> e[0], e -> parseStored(e[1]))));
 	}
 
 	private static Object substituteSimplify(String input) {

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -147,9 +147,13 @@ public class KeywordInterface {
 	 * @return {@code input} with all substitutions
 	 */
 	public static GeneralFunction substituteAll(GeneralFunction function) {
-		for (Map.Entry<String, GeneralFunction>  entry : storedFunctions.entrySet())
-			function = function.substituteVariable(LatexReplacer.encodeAll(entry.getKey()), entry.getValue());
-		return function;
+		//noinspection unchecked
+		return function.substituteVariable(
+					Map.ofEntries(storedFunctions.entrySet().stream()
+							.map(e -> Map.entry(LatexReplacer.encodeAll(e.getKey()), e.getValue()))
+							.toArray(Map.Entry[]::new)
+					)
+		);
 	}
 
 	private static String stripQuotes(String input) {
@@ -194,8 +198,8 @@ public class KeywordInterface {
 	}
 
 	private static GeneralFunction substitute(String input) {
-		String[] splitInput = keywordSplitter.split(input);
-		return parseStored(splitInput[0]).substituteVariable(LatexReplacer.encodeAll(splitInput[1]), parseStored(splitInput[2]));
+		String[] splitInput = keywordSplitter.split(input, 2);
+		return parseStored(splitInput[0]).substituteVariable(Arrays.stream(keywordSplitter.split(splitInput[1])).map(equals::split).collect(Collectors.toMap(e -> e[0], e -> parseStored(e[1]))));
 	}
 
 	private static Object substituteSimplify(String input) {

--- a/tests/KeywordInterfaceTest.java
+++ b/tests/KeywordInterfaceTest.java
@@ -80,7 +80,7 @@ public class KeywordInterfaceTest {
     @Test
     void notSoBasicSubstitute() {
         KeywordInterface.useKeywords("def t x^2");
-        GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("sa sub z+y y t");
+        GeneralFunction test1 = (GeneralFunction) KeywordInterface.useKeywords("sa sub z+y y=t");
         GeneralFunction test2 = FunctionParser.parseInfix("z+x^2");
         assertEquals(test2.simplify(), test1);
     }

--- a/tests/SubstituteTest.java
+++ b/tests/SubstituteTest.java
@@ -18,7 +18,7 @@ public class SubstituteTest {
         GeneralFunction test1 = FunctionParser.parseInfix("\\sin(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("y^2");
         GeneralFunction test3 = FunctionParser.parseInfix("\\sin(y^2)");
-        assertEquals(test1.substituteVariable(Map.of("x", test2)), test3);
+        assertEquals(test1.substituteVariables(Map.of("x", test2)), test3);
     }
 
     @Test
@@ -26,7 +26,7 @@ public class SubstituteTest {
         GeneralFunction test1 = FunctionParser.parseInfix("\\sin(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("x^2");
         GeneralFunction test3 = FunctionParser.parseInfix("\\sin(x^2)");
-        assertEquals(test1.substituteVariable(Map.of("x", test2)), test3);
+        assertEquals(test1.substituteVariables(Map.of("x", test2)), test3);
     }
 
     @Test
@@ -34,7 +34,7 @@ public class SubstituteTest {
         GeneralFunction test1 = FunctionParser.parseInfix("\\sin(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("x^2");
         GeneralFunction test3 = FunctionParser.parseInfix("\\sin(x)");
-        assertEquals(test1.substituteVariable(Map.of("y", test2)), test3);
+        assertEquals(test1.substituteVariables(Map.of("y", test2)), test3);
     }
 
     @Test

--- a/tests/SubstituteTest.java
+++ b/tests/SubstituteTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import parsing.FunctionParser;
 import tools.DefaultFunctions;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SubstituteTest {
@@ -16,7 +18,7 @@ public class SubstituteTest {
         GeneralFunction test1 = FunctionParser.parseInfix("\\sin(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("y^2");
         GeneralFunction test3 = FunctionParser.parseInfix("\\sin(y^2)");
-        assertEquals(test1.substituteVariable("x",test2), test3);
+        assertEquals(test1.substituteVariable(Map.of("x", test2)), test3);
     }
 
     @Test
@@ -24,7 +26,7 @@ public class SubstituteTest {
         GeneralFunction test1 = FunctionParser.parseInfix("\\sin(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("x^2");
         GeneralFunction test3 = FunctionParser.parseInfix("\\sin(x^2)");
-        assertEquals(test1.substituteVariable("x",test2), test3);
+        assertEquals(test1.substituteVariable(Map.of("x", test2)), test3);
     }
 
     @Test
@@ -32,7 +34,7 @@ public class SubstituteTest {
         GeneralFunction test1 = FunctionParser.parseInfix("\\sin(x)");
         GeneralFunction test2 = FunctionParser.parseInfix("x^2");
         GeneralFunction test3 = FunctionParser.parseInfix("\\sin(x)");
-        assertEquals(test1.substituteVariable("y",test2), test3);
+        assertEquals(test1.substituteVariable(Map.of("y", test2)), test3);
     }
 
     @Test


### PR DESCRIPTION
Makes `sub` more powerful by allowing the substitution of multiple variables at once, like the old `setv` function, and makes the internal substituteVariable method use a `Map<String, GeneralFunction>`.