### PR TITLE
Make default joining collectors static

### DIFF
--- a/src/functions/commutative/CommutativeFunction.java
+++ b/src/functions/commutative/CommutativeFunction.java
@@ -9,6 +9,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 /**
  * The abstract {@link CommutativeFunction} class represents function that are commutative. Ex: {@code addition} or {@code multiplication}
@@ -54,7 +55,9 @@ public abstract class CommutativeFunction extends GeneralFunction {
 	 * Returns a collector used to create the {@code toString} of the {@link CommutativeFunction}
 	 * @return a joining collector
 	 */
-	protected abstract Collector<CharSequence, ?, String> getJoiningCollector();
+	protected Collector<CharSequence, ?, String> getJoiningCollector() {
+		return Collectors.joining(", ", this.getClass().getSimpleName().toLowerCase() + "(", ")");
+	}
 
 	public boolean equalsFunction(GeneralFunction that) {
 		if (that instanceof CommutativeFunction function && this.getClass().equals(that.getClass()))

--- a/src/functions/commutative/Product.java
+++ b/src/functions/commutative/Product.java
@@ -17,6 +17,9 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class Product extends CommutativeFunction {
+
+	private static final Collector<CharSequence, ?, String> joiningCollector = Collectors.joining(" * ", "(", ")");
+
 	/**
 	 * Constructs a new {@link Product}
 	 * @param functions The terms being multiplied together
@@ -52,7 +55,7 @@ public class Product extends CommutativeFunction {
 	}
 
 	protected Collector<CharSequence, ?, String> getJoiningCollector() {
-		return Collectors.joining(" * ", "(", ")");
+		return joiningCollector;
 	}
 
 	public int compareSelf(GeneralFunction that) {

--- a/src/functions/commutative/Sum.java
+++ b/src/functions/commutative/Sum.java
@@ -15,6 +15,9 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class Sum extends CommutativeFunction {
+
+	private static final Collector<CharSequence, ?, String> joiningCollector = Collectors.joining(" + ", "(", ")");
+
 	/**
 	 * Constructs a new {@link Sum}
 	 * @param functions The terms being added together
@@ -47,7 +50,7 @@ public class Sum extends CommutativeFunction {
 	}
 
 	protected Collector<CharSequence, ?, String> getJoiningCollector() {
-		return Collectors.joining(" + ", "(", ")");
+		return joiningCollector;
 	}
 
 

--- a/src/functions/commutative/integer/IntegerCommutativeFunction.java
+++ b/src/functions/commutative/integer/IntegerCommutativeFunction.java
@@ -10,8 +10,6 @@ import tools.exceptions.DerivativeDoesNotExistException;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
 
 /**
  * {@link IntegerCommutativeFunction} provides resources for subclasses to implement mathematical functions with integer-restricted domain.
@@ -41,10 +39,6 @@ public abstract class IntegerCommutativeFunction extends CommutativeFunction {
 				.mapToInt(f -> ParsingTools.toInteger(f.evaluate(variableValues)))
 				.toArray();
 		return operateInt(toOperate);
-	}
-
-	protected Collector<CharSequence, ?, String> getJoiningCollector() {
-		return Collectors.joining(", ", this.getClass().getSimpleName().toLowerCase() + "(", ")");
 	}
 
 	public double operate(double a, double b) {


### PR DESCRIPTION
Makes the overriding collectors for joining toStrings in commutative functions static