### PR TITLE
Fix broken LaTeX escapes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@
  - Fix `toInteger` error message using the wrong margin from `Settings`
  - Fix bad rounding in `ParsingTools.toInteger` and `ParsingTools.isAlmostInteger`
  - Fix the evaluation of several arctrig functions 
+ - Fix parsing of non-escaped expressions with spaces such as `1 + sin(x)`
  
 ## v0.1.2
 ### Bugfixes

--- a/src/parsing/LatexReplacer.java
+++ b/src/parsing/LatexReplacer.java
@@ -162,7 +162,7 @@ public class LatexReplacer {
 		for (Collection<String> ops : List.of(binaryOperations.keySet(), unitaryOperations.keySet(), List.of("\\pi")))
 			for (String op : ops)
 				if (op.charAt(0) == '\\')
-					input = input.replaceAll("(?<!\\\\|a(rc)?)\\s*(?=" + op.substring(1) + ")", "\\\\");
+					input = input.replaceAll("(?<!\\\\|a(rc)?)(?=" + op.substring(1) + ")", "\\\\");
 		input = dx.matcher(input).replaceAll("\\\\");
 		return input;
 	}

--- a/tests/LatexTest.java
+++ b/tests/LatexTest.java
@@ -57,4 +57,9 @@ public class LatexTest {
 		assertEquals(1, test.evaluate(Map.of("x", 10.0)), .3);
 	}
 
+	@Test
+	void spaceEscapedLatex() {
+		GeneralFunction test = FunctionParser.parseInfix("1 + \\sin(x)");
+		assertEquals(1, test.evaluate(Map.of("x", 3.0)), .3);
+	}
 }

--- a/tests/NoEscapeTest.java
+++ b/tests/NoEscapeTest.java
@@ -94,4 +94,10 @@ public class NoEscapeTest {
 		assertEquals(DefaultFunctions.TWO, test1);
 		Settings.enforceEscapes = temp;
 	}
+
+	@Test
+	void spaceLatex() {
+		GeneralFunction test = FunctionParser.parseInfix("1 + sin(x)");
+		assertEquals(1, test.evaluate(Map.of("x", 3.0)), .3);
+	}
 }


### PR DESCRIPTION
Removes a space in the general regex of LatexReplacer to fix expressions like `1 + sin(x)` that have spaces.