### PR TITLE
Keyword interface improvements 1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@
  - Make `def` and `sub` in `CommandUI` now automatically perform a `minimalSimplify`
  - Add support for `_` in `evaluate` (used as `eval x^2 x=_` when `_` is a  `Double`)
  - Add `version` command to keyword interface
+ - Add `reset` command to keyword interface
  
  ### Bugfixes
  - Fix `toInteger` error message using the wrong margin from `Settings`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@
  - Make `substitute` more powerful in the UI by allowing the substitution of multiple expressions simultaneously
  - Make `def` and `sub` in `CommandUI` now automatically perform a `minimalSimplify`
  - Add support for `_` in `evaluate` (used as `eval x^2 x=_` when `_` is a  `Double`)
+ - Add `version` command to keyword interface
  
  ### Bugfixes
  - Fix `toInteger` error message using the wrong margin from `Settings`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,7 @@
  - Fix the evaluation of several arctrig functions 
  - Fix parsing of non-escaped expressions with spaces such as `1 + sin(x)`
  - Fix `defconstant` not latex escaping constant names
+ - Add an exception when user attempts to use nested quotes in `KeywordInterface`
  
 ## v0.1.2
 ### Bugfixes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,19 +13,19 @@
  - Add new test class for integer operations
  - Change `equals` to check if two functions are exactly equal and implement `equalsSimplified` to check if they are equal when simplified
  - Add `DerivativeDoesNotExistException` for operations with no derivative
- - Make `substitute` more powerful in the UI by allowing the substitution of multiple expressions simultaneously
- - Make `def` and `sub` in `CommandUI` now automatically perform a `minimalSimplify`
+ - Make `substitute`/`sub` more powerful in the keyword interface by allowing the substitution of multiple expressions simultaneously
+ - Make `def` and `sub` in automatically perform a `minimalSimplify`
  - Add support for `_` in `evaluate` (used as `eval x^2 x=_` when `_` is a  `Double`)
- - Add `version` command to keyword interface
- - Add `reset` command to keyword interface
+ - Add `version` command
+ - Add `reset` command
  
  ### Bugfixes
  - Fix `toInteger` error message using the wrong margin from `Settings`
  - Fix bad rounding in `ParsingTools.toInteger` and `ParsingTools.isAlmostInteger`
  - Fix the evaluation of several arctrig functions 
  - Fix parsing of non-escaped expressions with spaces such as `1 + sin(x)`
- - Fix `defconstant` not latex escaping constant names
- - Add an exception when user attempts to use nested quotes in `KeywordInterface`
+ - Fix `defconstant` not LaTeX-escaping constant names
+ - Add an exception when user attempts to use nested quotes in keyword interface
  
 ## v0.1.2
 ### Bugfixes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,7 @@
  - Fix bad rounding in `ParsingTools.toInteger` and `ParsingTools.isAlmostInteger`
  - Fix the evaluation of several arctrig functions 
  - Fix parsing of non-escaped expressions with spaces such as `1 + sin(x)`
+ - Fix `defconstant` not latex escaping constant names
  
 ## v0.1.2
 ### Bugfixes

--- a/src/functions/special/Constant.java
+++ b/src/functions/special/Constant.java
@@ -130,6 +130,13 @@ public class Constant extends SpecialFunction {
 		return (that instanceof Constant) && (Math.abs(constant - ((Constant) that).constant) < Settings.equalsMargin);
 	}
 
+	public static void resetConstants() {
+		specialConstants.clear();
+		specialConstants.put("π", Math.PI);
+		specialConstants.put("e", Math.E);
+	}
+
+
 	@SuppressWarnings({"VariableNotUsedInsideIf", "ConstantConditions"})
 	public int compareSelf(GeneralFunction that) {
 		if (constantKey != null && ((Constant) that).constantKey != null)

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -256,9 +256,9 @@ public class KeywordInterface {
 	private static Object defineConstant(String input) {
 		String[] splitInput = spaces.split(input, 2);
 		try {
-			return Constant.addSpecialConstant(splitInput[0], ((GeneralFunction) KeywordInterface.useKeywords(splitInput[1])).evaluate(null));
+			return Constant.addSpecialConstant(LatexReplacer.encodeAll(splitInput[0]), ((GeneralFunction) KeywordInterface.useKeywords(splitInput[1])).evaluate(null));
 		} catch (Exception e) {
-			return Constant.addSpecialConstant(splitInput[0], parseStored(splitInput[1]).evaluate(null));
+			return Constant.addSpecialConstant(LatexReplacer.encodeAll(splitInput[0]), parseStored(splitInput[1]).evaluate(null));
 		}
 	}
 

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -404,7 +404,7 @@ public class KeywordInterface {
 					"ai [index]";
 			case "version"															-> "Prints the version of CASprzak which is currently being run. \n" +
 					"version";
-			case "reset"															-> "Resets functions and constants. \n" +
+			case "reset"															-> "Resets stored functions and constants to their initial state. \n" +
 					"reset";
 			case "help"				                                      			-> "Gives more information about a command. [argument] denotes a necessary argument, (argument) denotes an optional argument, and (argument)* denotes zero or more instances of argument.\n" +
 					"help (command)";

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -443,7 +443,7 @@ public class KeywordInterface {
 				ps, prints, printsettings:                             prints all settings
 				clearfun, clearfunctions:                              clears functions
 				version:											   prints version
-				reset:												   resets
+				reset:                                                 resets functions and constants
 				exit, !:                                               exits the interface
 				Execute `help [command]` to get more info on that command, and `help help` for more info on the help menu.
 				""";

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -406,6 +406,8 @@ public class KeywordInterface {
 					"ai [index]";
 			case "version"															-> "Prints the version of CASprzak which is currently being run. \n" +
 					"version";
+			case "reset"															-> "Resets stored object, functions, and constants" +
+					"reset";
 			case "help"				                                      			-> "Gives more information about a command. [argument] denotes a necessary argument, (argument) denotes an optional argument, and (argument)* denotes zero or more instances of argument.\n" +
 					"help (command)";
 			case "exit", "!"														-> "Exits the program.\n" +

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -393,6 +393,8 @@ public class KeywordInterface {
 					"int [function] d[variable]";
 			case "ai", "index", "arrayindex"										-> "Assuming that the output of the previous command was a list, returns the value at index [index] in the list.\n" +
 					"ai [index]";
+			case "version"															-> "Prints the version of CASprzak which is currently being run. \n" +
+					"version";
 			case "help"				                                      			-> "Gives more information about a command. [argument] denotes a necessary argument, (argument) denotes an optional argument, and (argument)* denotes zero or more instances of argument.\n" +
 					"help (command)";
 			case "exit", "!"														-> "Exits the program.\n" +
@@ -429,6 +431,7 @@ public class KeywordInterface {
 				ss, sets, setsetting:                                  sets a setting
 				ps, prints, printsettings:                             prints all settings
 				clearfun, clearfunctions:                              clears functions
+				version:											   prints version
 				exit, !:                                               exits the interface
 				Execute `help [command]` to get more info on that command, and `help help` for more info on the help menu.
 				""";

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -80,6 +80,7 @@ public class KeywordInterface {
 			case "ai", "index", "arrayindex"									-> arrayIndex(splitInput[1]);
 			case "debug"														-> debug(splitInput[1]);
 			case "version"														-> version;
+			case "reset"														-> reset();
 			case "help"															-> splitInput.length == 1 ? help() : help(splitInput[1]);
 			case "exit", "!"													-> throw new IllegalArgumentException("Exit command should never be passed directly to KeywordInterface. Please report this bug to the developers.");
 			default 															-> null;
@@ -339,6 +340,14 @@ public class KeywordInterface {
 			return (Double) list.get(Integer.parseInt(input));
 		} else
 			throw new IllegalArgumentException("The previous output was not a list of numbers.");
+	}
+
+	private static String reset() {
+		clearFunctions();
+		Constant.specialConstants.clear();
+		Constant.specialConstants.put("π", Math.PI);
+		Constant.specialConstants.put("e", Math.E);
+		return "Reset done";
 	}
 
 	private static String help(String input) {

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -443,7 +443,7 @@ public class KeywordInterface {
 				ps, prints, printsettings:                             prints all settings
 				clearfun, clearfunctions:                              clears functions
 				version:											   prints version
-				reset:                                                 resets functions and constants
+				reset:                                                 resets stored functions and constants
 				exit, !:                                               exits the interface
 				Execute `help [command]` to get more info on that command, and `help help` for more info on the help menu.
 				""";

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -445,6 +445,7 @@ public class KeywordInterface {
 				ps, prints, printsettings:                             prints all settings
 				clearfun, clearfunctions:                              clears functions
 				version:											   prints version
+				reset:												   resets
 				exit, !:                                               exits the interface
 				Execute `help [command]` to get more info on that command, and `help help` for more info on the help menu.
 				""";

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("SpellCheckingInspection")
 public class KeywordInterface {
+	private static final String version = "0.2.0-DEV";
 	private static final Pattern keywordSplitter = Pattern.compile("\\s+(?=[^\"]*(\"[^\"]*\"[^\"]*)*$)");
 	private static final Pattern spaces = Pattern.compile("\\s+");
 	private static final Pattern equals = Pattern.compile("=");
@@ -78,6 +79,7 @@ public class KeywordInterface {
 			case "int", "integral"												-> integral(splitInput[1]);
 			case "ai", "index", "arrayindex"									-> arrayIndex(splitInput[1]);
 			case "debug"														-> debug(splitInput[1]);
+			case "version"														-> version;
 			case "help"															-> splitInput.length == 1 ? help() : help(splitInput[1]);
 			case "exit", "!"													-> throw new IllegalArgumentException("Exit command should never be passed directly to KeywordInterface. Please report this bug to the developers.");
 			default 															-> null;

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -404,7 +404,7 @@ public class KeywordInterface {
 					"ai [index]";
 			case "version"															-> "Prints the version of CASprzak which is currently being run. \n" +
 					"version";
-			case "reset"															-> "Resets stored object, functions, and constants" +
+			case "reset"															-> "Resets functions and constants. \n" +
 					"reset";
 			case "help"				                                      			-> "Gives more information about a command. [argument] denotes a necessary argument, (argument) denotes an optional argument, and (argument)* denotes zero or more instances of argument.\n" +
 					"help (command)";

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -166,6 +166,8 @@ public class KeywordInterface {
 			String stripped = input.substring(1, input.length() - 1);
 			if (!stripped.contains("\""))
 				return stripped;
+			else
+				throw new IllegalArgumentException("Nested quotes are not supported.");
 		}
 		return input;
 	}

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -346,9 +346,7 @@ public class KeywordInterface {
 
 	private static String reset() {
 		clearFunctions();
-		Constant.specialConstants.clear();
-		Constant.specialConstants.put("π", Math.PI);
-		Constant.specialConstants.put("e", Math.E);
+		Constant.resetConstants();
 		return "Reset done";
 	}
 

--- a/src/ui/CommandUI.java
+++ b/src/ui/CommandUI.java
@@ -57,7 +57,7 @@ public class CommandUI {
 			else
 				System.out.println(object);
 		} else {
-			System.out.println("Done");
+			System.out.println("Output is empty.");
 		}
 	}
 }


### PR DESCRIPTION
- Add a 'version' command
- Add a 'reset' command
- Fix 'defconstant' not latex escaping the constant name
- Throw an error when attempting to use nested quotes
