### PR TITLE
Fix quotes splitting in eval

### DIFF
--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -191,7 +191,7 @@ public class KeywordInterface {
 	}
 
 	private static double evaluate(String input) {
-		String[] splitInput = spaces.split(input, 2);
+		String[] splitInput = keywordSplitter.split(input, 2);
 		if (splitInput.length == 1)
 			return parseStored(splitInput[0]).evaluate(new HashMap<>());
 		else {


### PR DESCRIPTION
Fixes splitting of expressions like `eval "sa f" x=2` where `f` is a defined function in terms of `x`