### PR TITLE
Division by decimals

### DIFF
--- a/src/parsing/InfixTokenizer.java
+++ b/src/parsing/InfixTokenizer.java
@@ -48,7 +48,7 @@ public class InfixTokenizer {
 			(Settings.doCombinatorics ?  "|(?=[CP])" : "") +		// Splits if followed by a C or P and Settings.doCombinatorics is on
 			"|(?<=[()])|(?=[()]))" +								// Splits if preceded or followed by a parenthesis
 			"(?<![ .\\\\])(?![ .])" +								// The lines after "followed by LaTeX escape" ONLY WORK if not preceded or followed by a period or space, and not preceded by a LaTeX escape
-			"|(?<=\\D)(?=\\.)" +									// Splits if preceded by a letter and followed by a period
+			"|(?<=\\D)(?=\\.)" +									// Splits if preceded by a non-digit and followed by a period
 			"|(?<=\\()(?=\\.))"										// Splits if preceded by an open parenthesis and followed by a period
 	);
 	private static final Pattern characterPairMultiplier = Pattern.compile(

--- a/src/parsing/InfixTokenizer.java
+++ b/src/parsing/InfixTokenizer.java
@@ -43,12 +43,12 @@ public class InfixTokenizer {
 			"|(?<!\\s)(?=\\\\)" +									// Splits if followed by a LaTeX escape
 			"|(((?<=\\W)(?=[\\w-])((?<!-)|(?!\\d))" +				// Splits if preceded by non-word and followed by word and not [preceded by - and followed by a digit]
 			"|(?<=\\w)(?=\\W)((?<!E)|(?!-)))" +						// Splits if preceded by a word and followed by a non-word, unless [the word was E and the non-word was -]
-			"|(?<=[a-zA-Z])(?=\\.)" +								// Splits if preceded by a letter and followed by a period
 			"|(?<=[^\\x00-\\x7F])|(?=[^\\x00-\\x7F])" +				// Splits if preceded or followed by a non-ASCII character
 			(Settings.doCombinatorics ? "|(?<=[CP])" : "") +		// Splits if preceded by a C or P and Settings.doCombinatorics is on
 			(Settings.doCombinatorics ?  "|(?=[CP])" : "") +		// Splits if followed by a C or P and Settings.doCombinatorics is on
 			"|(?<=[()])|(?=[()]))" +								// Splits if preceded or followed by a parenthesis
 			"(?<![ .\\\\])(?![ .])" +								// The lines after "followed by LaTeX escape" ONLY WORK if not preceded or followed by a period or space, and not preceded by a LaTeX escape
+			"|(?<=\\D)(?=\\.)" +									// Splits if preceded by a letter and followed by a period
 			"|(?<=\\()(?=\\.))"										// Splits if preceded by an open parenthesis and followed by a period
 	);
 	private static final Pattern characterPairMultiplier = Pattern.compile(

--- a/tests/FunctionTest.java
+++ b/tests/FunctionTest.java
@@ -326,4 +326,9 @@ public class FunctionTest {
 		assertEquals(1.5, test.evaluate(Map.of()), 0.001);
 	}
 
+	@Test void divideByDecimal() {
+		GeneralFunction test = FunctionParser.parseSimplified("1/.2");
+		assertEquals(5.0, test.evaluate(Map.of()), .000001);
+	}
+
 }

--- a/tests/FunctionTest.java
+++ b/tests/FunctionTest.java
@@ -326,9 +326,18 @@ public class FunctionTest {
 		assertEquals(1.5, test.evaluate(Map.of()), 0.001);
 	}
 
-	@Test void divideByDecimal() {
-		GeneralFunction test = FunctionParser.parseSimplified("1/.2");
+	@Test void noLeadingZero() {
+		GeneralFunction test;
+		test = FunctionParser.parseSimplified("1+.2");
+		assertEquals(1.2, test.evaluate(Map.of()), .000001);
+		test = FunctionParser.parseSimplified("1-.2");
+		assertEquals(0.8, test.evaluate(Map.of()), .000001);
+		test = FunctionParser.parseSimplified("5*.2");
+		assertEquals(1.0, test.evaluate(Map.of()), .000001);
+		test = FunctionParser.parseSimplified("1/.2");
 		assertEquals(5.0, test.evaluate(Map.of()), .000001);
+		test = FunctionParser.parseSimplified("9^.5");
+		assertEquals(3.0, test.evaluate(Map.of()), .000001);
 	}
 
 }


### PR DESCRIPTION
Fixes expressions like `1/.2` where division occurs with a non-leading-zero decimal