### PR TITLE
Keyword interface touchup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+# v0.2.1
+### Minor Additions
+ - Add 'v' to the version String from the `version` command
+### Bugfixes
+ - Fix malformed whitespace in the `help` command
 # v0.2.0
 ### Major Additions 
  - Integer division (with `//`), modulo, lcm, and gcd operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 # v0.2.1
 ### Minor Additions
  - Add 'v' to the version String from the `version` command
+ - Add `v` as another way to call `version` in KeywordInterface
+ - Add a period to the end of 'Reset done.'
 ### Bugfixes
  - Fix malformed whitespace in the `help` command
 # v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 # v0.2.1
 ### Minor Additions
- - Add 'v' to the version String from the `version` command
- - Add `v` as another way to call `version` in KeywordInterface
- - Add a period to the end of 'Reset done.'
+ - Add 'v' to the version string of the `version` command
+ - Add `v` alias for `version` in KeywordInterface
 ### Bugfixes
  - Fix malformed whitespace in the `help` command
+ 
 # v0.2.0
 ### Major Additions 
  - Integer division (with `//`), modulo, lcm, and gcd operations

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -518,7 +518,7 @@ public class KeywordInterface {
 				ss, sets, setsetting:                                  sets a setting
 				ps, prints, printsettings:                             prints all settings
 				clearfun, clearfunctions:                              clears functions
-				version:											   prints version
+				version:                                               prints version
 				reset:                                                 resets stored functions and constants
 				err, error:                                            prints the details of the previous error
 				exit, !:                                               exits the interface

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("SpellCheckingInspection")
 public class KeywordInterface {
-	private static final String version = "0.2.1";
+	private static final String version = "v0.2.1";
 	private static final Pattern keywordSplitter = Pattern.compile("\\s+(?=[^\"]*(\"[^\"]*\"[^\"]*)*$)");
 	private static final Pattern spaces = Pattern.compile("\\s+");
 	private static final Pattern equals = Pattern.compile("=");

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -82,7 +82,7 @@ public class KeywordInterface {
 				case "int", "integral" 																-> integral(splitInput[1]);
 				case "ai", "index", "arrayindex" 													-> arrayIndex(splitInput[1]);
 				case "debug" 																		-> debug(splitInput[1]);
-				case "version" 																		-> version;
+				case "version", "v" 																		-> version;
 				case "reset" 																		-> reset();
 				case "err", "error" 																-> printError();
 				case "help" 																		-> splitInput.length == 1 ? help() : help(splitInput[1]);
@@ -476,7 +476,7 @@ public class KeywordInterface {
 					"int [function] d[variable]";
 			case "ai", "index", "arrayindex"										-> "Assuming that the output of the previous command was a list, returns the value at index [index] in the list.\n" +
 					"ai [index]";
-			case "version"															-> "Prints the version of CASprzak which is currently being run. \n" +
+			case "version", "v"														-> "Prints the version of CASprzak which is currently being run. \n" +
 					"version";
 			case "reset"															-> "Resets stored functions and constants to their initial state. \n" +
 					"reset";
@@ -518,7 +518,7 @@ public class KeywordInterface {
 				ss, sets, setsetting:                                  sets a setting
 				ps, prints, printsettings:                             prints all settings
 				clearfun, clearfunctions:                              clears functions
-				version:                                               prints version
+				version, v:                                            prints version
 				reset:                                                 resets stored functions and constants
 				err, error:                                            prints the details of the previous error
 				exit, !:                                               exits the interface

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("SpellCheckingInspection")
 public class KeywordInterface {
-	private static final String version = "0.2.0";
+	private static final String version = "0.2.1";
 	private static final Pattern keywordSplitter = Pattern.compile("\\s+(?=[^\"]*(\"[^\"]*\"[^\"]*)*$)");
 	private static final Pattern spaces = Pattern.compile("\\s+");
 	private static final Pattern equals = Pattern.compile("=");

--- a/src/parsing/KeywordInterface.java
+++ b/src/parsing/KeywordInterface.java
@@ -414,7 +414,7 @@ public class KeywordInterface {
 	private static String reset() {
 		clearFunctions();
 		Constant.resetConstants();
-		return "Reset done";
+		return "Reset done.";
 	}
 
 	private static String printError() {


### PR DESCRIPTION
 - Fix malformed whitespace in the `help` command
 - Add 'v' to the version String from the `version` command
- Add `v` as another way to call `version` in KeywordInterface
 - Add a period to the end of 'Reset done.'
