### PR TITLE
Fix broken LaTeX escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 ## v0.3.0
 ### Bugfixes
-- Fix `Differential` comparison causing `NullPointerException`s
+ - Fix `Differential` comparison causing `NullPointerException`s
+ - Fix inputs like `sinner` being parsed to the variable `\sinner` rather than a product
 
 
 ## v0.2.1

--- a/src/parsing/InfixTokenizer.java
+++ b/src/parsing/InfixTokenizer.java
@@ -26,7 +26,7 @@ public class InfixTokenizer {
 			"|(?<=[a-zA-Z])(?<![" + splitExcpt + "])(?=[\\d]))" +	// Matches if preceded by a non-ECP letter and followed by a digit
 			"|(?<=\\))(?=[\\w(])" + 								// Matches if preceded by ) and followed by a word character or (
 			"|(?<=\\))(?=\\.)" +									// Matches if preceded by a letter or ) and followed by a period
-			"|(?<=[\\d)])(?=\\()(?<!logb_\\d)"						// Matches if preceded by [a digit not preceded by logb_] or ) and followed by (
+			"|(?<=[\\d)])(?=\\()(?<!logb\\s?_\\d)"						// Matches if preceded by [a digit not preceded by logb_] or ) and followed by (
 	);
 	private static final Pattern subtractionFinder = Pattern.compile(
 			"(?<!^)(?<!E)" +										// Ensures not preceded by newline or E
@@ -54,7 +54,7 @@ public class InfixTokenizer {
 	private static final Pattern characterPairMultiplier = Pattern.compile(
 			"(?<!\\\\[\\w.']{0," + maxEscapeLength + "})" +			// Ensures that the character is not LaTeX-escaped (up to Settings.maxEscapeLength characters)
 			"(?<![CEP])(?![CEP])" +									// Ensures the spaces before and after C, E, and P are not matched
-			"(?<!logb_\\w)" +										// Ensures not preceded by \logb_{character}
+			"(?<!logb\\s?_\\w)" +										// Ensures not preceded by \logb_{character}
 			"((?<!\\d)|(?!\\d))" +									// Ensures that spaces both preceded and followed by a digit are not matched
 			"(?<=[a-zA-Z)\\d[^\\x00-\\x7F]])" +						// Preceded by a digit, alphabetic char, or non-ascii character
 			"\\s*" + 												// Allows for spaces
@@ -68,7 +68,7 @@ public class InfixTokenizer {
 			"(?<=\\\\pd\\{([a-zA-Z[^\\x00-\\x7F]]))"
 	);
 	private static final Pattern division = Pattern.compile("(?<!/)/(?!/)");
-	private static final Pattern logbUnderscores = Pattern.compile("logb_");
+	private static final Pattern logbUnderscores = Pattern.compile("logb\\s?_");
 
 	private InfixTokenizer(){}
 

--- a/src/parsing/LatexReplacer.java
+++ b/src/parsing/LatexReplacer.java
@@ -82,6 +82,7 @@ public class LatexReplacer {
 	};
 	
 	private static final Pattern dx = Pattern.compile("(?<![\\\\/])(?=d[a-ce-zA-Z](?![a-zA-Z]))");
+	private static final Pattern pi = Pattern.compile("(?<!\\\\)pi");
 	private static final Pattern splitEscapes = Pattern.compile("(?=\\\\)");
 
 	/**
@@ -115,10 +116,11 @@ public class LatexReplacer {
 	 * @return the input with LaTeX escapes inserted as specified above
 	 */
 	public static String addEscapes(String input) {
-		for (Collection<String> ops : List.of(binaryOperations.keySet(), unitaryOperations.keySet(), List.of("\\pi")))
+		for (Collection<String> ops : List.of(binaryOperations.keySet(), unitaryOperations.keySet()))
 			for (String op : ops)
 				if (op.charAt(0) == '\\')
-					input = input.replaceAll("(?<!\\\\|a(rc)?)(?=" + op.substring(1) + ")", "\\\\");
+					input = input.replaceAll("(?<!\\\\|a(rc)?)(?=" + op.substring(1) + "[\\s(])", "\\\\");
+		input = pi.matcher(input).replaceAll("\\\\pi");
 		input = dx.matcher(input).replaceAll("\\\\");
 		return input;
 	}

--- a/src/parsing/LatexReplacer.java
+++ b/src/parsing/LatexReplacer.java
@@ -83,6 +83,7 @@ public class LatexReplacer {
 	
 	private static final Pattern dx = Pattern.compile("(?<![\\\\/])(?=d[a-ce-zA-Z](?![a-zA-Z]))");
 	private static final Pattern pi = Pattern.compile("(?<!\\\\)pi");
+	private static final Pattern logb = Pattern.compile("(?<!\\\\)logb_");
 	private static final Pattern splitEscapes = Pattern.compile("(?=\\\\)");
 
 	/**
@@ -122,6 +123,7 @@ public class LatexReplacer {
 					input = input.replaceAll("(?<!\\\\|a(rc)?)(?=" + op.substring(1) + "[\\s(])", "\\\\");
 		input = pi.matcher(input).replaceAll("\\\\pi");
 		input = dx.matcher(input).replaceAll("\\\\");
+		input = logb.matcher(input).replaceAll("\\\\logb _");
 		return input;
 	}
 

--- a/tests/LatexTest.java
+++ b/tests/LatexTest.java
@@ -1,4 +1,5 @@
 import functions.GeneralFunction;
+import functions.commutative.Product;
 import functions.endpoint.Variable;
 import functions.unitary.trig.normal.Sin;
 import org.junit.jupiter.api.Test;
@@ -78,7 +79,7 @@ public class LatexTest {
 
 	@Test
 	void sinx() {
-		GeneralFunction test = FunctionParser.parseInfix("sinx");
-		assertEquals(new Sin(new Variable("x")), test);
+		GeneralFunction test = FunctionParser.parseSimplified("sinx");
+		assertEquals(FunctionParser.parseSimplified("s*i*n*x"), test);
 	}
 }


### PR DESCRIPTION
Fixes:
 - Inputs like `sinner` being escaped to the variable `\sinner` rather than `s*i*n*n*e*r`
 - Logb parsing failing on edge cases