### PR TITLE
Add basic Gradle instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ All documentation for CASprzak can be found at: https://ezkz.show/CASprzak-docum
   - Demo command demonstrating core features
 
 ## Usage
-
 1. Download the latest release jar from the `Releases` tab
 2. Ensure you are running Java 14
 3. Launch the program in your favorite command line using `java -jar --enable-preview CASprzak.jar` 
@@ -48,13 +47,11 @@ All documentation for CASprzak can be found at: https://ezkz.show/CASprzak-docum
 ## Build and Test
 
 This project uses Gradle for building and testing. To build and test CASprzak, run this command in a terminal:
-
 ```shell
 ./gradlew build
 ```
 
 On Windows, run this in Command Prompt:
-
 ```
 gradlew.bat build
 ```
@@ -62,7 +59,6 @@ gradlew.bat build
 A combined JAR for distribution will be created in `build/libs`. JARS of individual libraries will be created in `core/build/libs`, `parsing/build/libs`, and `commandui/build/libs`.
 
 ## Contacts
-
 ### Group
 The EasyKayzey Show: easykayzey@ezkz.show
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All documentation for CASprzak can be found at: https://ezkz.show/CASprzak-docum
   - Demo command demonstrating core features
 
 ## Usage
+
 1. Download the latest release jar from the `Releases` tab
 2. Ensure you are running Java 14
 3. Launch the program in your favorite command line using `java -jar --enable-preview CASprzak.jar` 
@@ -44,7 +45,24 @@ All documentation for CASprzak can be found at: https://ezkz.show/CASprzak-docum
    - If you are using the source code, leave the file in `src/config`
 - Binaries are available for all stable releases under the `Releases` tab
 
+## Build and Test
+
+This project uses Gradle for building and testing. To build and test CASprzak, run this command in a terminal:
+
+```shell
+./gradlew build
+```
+
+On Windows, run this in Command Prompt:
+
+```
+gradlew.bat build
+```
+
+A combined JAR for distribution will be created in `build/libs`. JARS of individual libraries will be created in `core/build/libs`, `parsing/build/libs`, and `commandui/build/libs`.
+
 ## Contacts
+
 ### Group
 The EasyKayzey Show: easykayzey@ezkz.show
 


### PR DESCRIPTION
This PR adds some basic instructions to the README for building and testing with Gradle.