### PR TITLE
Add Gradle run instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ gradlew.bat build
 
 A combined JAR for distribution will be created in `build/libs`. JARS of individual libraries will be created in `core/build/libs`, `parsing/build/libs`, and `commandui/build/libs`.
 
+To run the command line UI directly, use `./gradlew commandui:run` or `gradlew.bat commandui:run`.
+
 ## Contacts
 ### Group
 The EasyKayzey Show: easykayzey@ezkz.show


### PR DESCRIPTION
This PR adds instructions for running the command UI directly from Gradle to the README.
