### PR TITLE
Tutorial fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Bugfixes
  - Fix `Differential` comparison causing `NullPointerException`s
  - Fix inputs like `sinner` being parsed to the variable `\sinner` rather than a product
+ - Fix `enforceEscapes` not being a setting
+ - Fix inconsistent variable names in the tutorial
+ - Fix the CAS automatically simplifying expressions in the simplify section
 
 
 ## v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 ## v0.3.0
+### Major Additions
+ - Add Gradle management
+ - Package CASprzak into `core`, `parsing` and `commandui`
+ - Publish to Maven central repository
+### Changes
+ - Rename various escape-related settings
 ### Bugfixes
  - Fix `Differential` comparison causing `NullPointerException`s
  - Fix inputs like `sinner` being parsed to the variable `\sinner` rather than a product
- - Fix `enforceEscapes` not being a setting
  - Fix inconsistent variable names in the tutorial
- - Fix the CAS automatically simplifying expressions in the simplify section
+ - Fix CASDemo automatically simplifying expressions in the SIMP section
 
 
 ## v0.2.1

--- a/commandui/src/java/show/ezkz/casprzak/commandui/CASDemo.java
+++ b/commandui/src/java/show/ezkz/casprzak/commandui/CASDemo.java
@@ -243,22 +243,18 @@ public class CASDemo {
 	private static void simp() {
 		printWithSleep("""
 				Now, one of the most important features of our CAS is its ability to simplify expressions.
-				For example:
-				>>> def d x^2*(0*ln(x)+(2*1)/x)
-				""" +
-				KeywordInterface.safeKeywords("def d x^2*(0*ln(x)+(2*1)/x)")
-				+ """
-    
+				For example take the expression:
+				x^2*(0*ln(x)+(2*1)/x)
 				This expression looks complicated, right?
-				Try typing 'simp d' to return a simplified form of the expression.
-				""");
-		if (!tryInput(s -> s.length() > 4 && "simp ".equals(s.substring(0, 5)), "Begin your input with 'simp' to demonstrate the simplification feature of the UI."))
-			return;
-		sleep();
-		printWithSleep("""
+				""" +
+						KeywordInterface.safeKeywords("def d x^2*(0*ln(x)+(2*1)/x)")
+				+ """
 				Wow, quite the improvement.
+				The CAS automatically simplified the trivial steps like multiplication by 1 or adding zero.
 				For those who are curious, that was the general formula of the derivative of 'f(x)^g(x)' applied to 'x^2'.
+				If you want to explicitly simplify a function, use 'simp _' for example. 
 				Also, if you want to define a function and simplify it in one step, you can use the 'defs' or 'deffunctionsimplify'.
+				These explicit calls to simplify will perform extra simplifications such as distributing across addition.  
 				Continue testing this feature, or type 'next' to continue.
 				""");
 		currentState = DemoState.VAR;

--- a/commandui/src/java/show/ezkz/casprzak/commandui/CASDemo.java
+++ b/commandui/src/java/show/ezkz/casprzak/commandui/CASDemo.java
@@ -246,11 +246,14 @@ public class CASDemo {
 				For example take the expression:
 				x^2*(0*ln(x)+(2*1)/x)
 				This expression looks complicated, right?
+				Let's feed it through the CAS:
+				>>> def d x^2*(0*ln(x)+(2*1)/x)
 				""" +
-						KeywordInterface.safeKeywords("def d x^2*(0*ln(x)+(2*1)/x)")
+				KeywordInterface.safeKeywords("def d x^2*(0*ln(x)+(2*1)/x)")
 				+ """
+						
 				Wow, quite the improvement.
-				The CAS automatically simplified the trivial steps like multiplication by 1 or adding zero.
+				The CAS automatically simplified trivial steps like multiplication by 1 or adding 0.
 				For those who are curious, that was the general formula of the derivative of 'f(x)^g(x)' applied to 'x^2'.
 				If you want to explicitly simplify a function, use 'simp _' for example. 
 				Also, if you want to define a function and simplify it in one step, you can use the 'defs' or 'deffunctionsimplify'.

--- a/commandui/src/java/show/ezkz/casprzak/commandui/CASDemo.java
+++ b/commandui/src/java/show/ezkz/casprzak/commandui/CASDemo.java
@@ -276,7 +276,7 @@ public class CASDemo {
 		sleep();
 		printWithSleep("""
 				Now, when evaluating, you will need to specify each value, like 'eval x-y x=2 y=3'.
-				Try evaluating your multivariable function using 'eval', e.g. 'eval f x=2 y=4 q=e.
+				Try evaluating your multivariable function using 'eval', e.g. 'eval g x=2 y=4 q=e.
 				""", 2);
 		if (!tryInput(s -> s.length() > 4 && "eval ".equals(s.substring(0, 5)), "Begin your input with 'eval'"))
 			return;

--- a/core/src/java/show/ezkz/casprzak/core/config/Settings.java
+++ b/core/src/java/show/ezkz/casprzak/core/config/Settings.java
@@ -198,8 +198,8 @@ public class Settings {
 			case "integerMargin" 							-> integerMargin = Double.parseDouble(value);
 			case "equalsMargin" 							-> equalsMargin = Double.parseDouble(value);
 			case "defaultSleep"								-> defaultSleep = Double.parseDouble(value);
-			case "enforceEscapedFunctions"		 			-> enforceEscapes = ParsingTools.parseBoolean(value);
-			case "enforceEscapedNames"		 				-> escapeNames = ParsingTools.parseBoolean(value);
+			case "enforceEscapes"				 			-> enforceEscapes = ParsingTools.parseBoolean(value);
+			case "escapedNames"				 				-> escapeNames = ParsingTools.parseBoolean(value);
 			case "enforcePatternMatchingNames"		 		-> enforcePatternMatchingNames = ParsingTools.parseBoolean(value);
 			case "removeEscapes"		 					-> removeEscapes = ParsingTools.parseBoolean(value);
 			case "simplifyFunctionsOfConstants" 			-> simplifyFunctionsOfConstants = ParsingTools.parseBoolean(value);

--- a/core/src/java/show/ezkz/casprzak/core/config/Settings.java
+++ b/core/src/java/show/ezkz/casprzak/core/config/Settings.java
@@ -74,7 +74,7 @@ public class Settings {
 	/**
 	 * Denotes whether or not expressions like {@code sin(pi/2)} must be escaped to {@code \sin(\pi/2)}. Enabling this is strongly recommended, and may reduce bugs.
 	 */
-	public static boolean enforceEscapedFunctions = false;
+	public static boolean enforceEscapes = false;
 
 	/**
 	 * Denotes whether or not the regex for valid variable, function, and constant names should enforce a LaTeX escape in multi-character names. Enabling this may improve error handling.
@@ -198,7 +198,7 @@ public class Settings {
 			case "integerMargin" 							-> integerMargin = Double.parseDouble(value);
 			case "equalsMargin" 							-> equalsMargin = Double.parseDouble(value);
 			case "defaultSleep"								-> defaultSleep = Double.parseDouble(value);
-			case "enforceEscapedFunctions"		 			-> enforceEscapedFunctions = ParsingTools.parseBoolean(value);
+			case "enforceEscapedFunctions"		 			-> enforceEscapes = ParsingTools.parseBoolean(value);
 			case "enforceEscapedNames"		 				-> enforceEscapedNames = ParsingTools.parseBoolean(value);
 			case "enforcePatternMatchingNames"		 		-> enforcePatternMatchingNames = ParsingTools.parseBoolean(value);
 			case "removeEscapes"		 					-> removeEscapes = ParsingTools.parseBoolean(value);

--- a/core/src/java/show/ezkz/casprzak/core/config/Settings.java
+++ b/core/src/java/show/ezkz/casprzak/core/config/Settings.java
@@ -79,7 +79,7 @@ public class Settings {
 	/**
 	 * Denotes whether or not the regex for valid variable, function, and constant names should enforce a LaTeX escape in multi-character names. Enabling this may improve error handling.
 	 */
-	public static boolean enforceEscapedNames = true;
+	public static boolean escapeNames = true;
 
 	/**
 	 * Denotes whether or not variable, function, and constant names should be checked against the valid name regex {@link ParsingTools#validNames}
@@ -199,7 +199,7 @@ public class Settings {
 			case "equalsMargin" 							-> equalsMargin = Double.parseDouble(value);
 			case "defaultSleep"								-> defaultSleep = Double.parseDouble(value);
 			case "enforceEscapedFunctions"		 			-> enforceEscapes = ParsingTools.parseBoolean(value);
-			case "enforceEscapedNames"		 				-> enforceEscapedNames = ParsingTools.parseBoolean(value);
+			case "enforceEscapedNames"		 				-> escapeNames = ParsingTools.parseBoolean(value);
 			case "enforcePatternMatchingNames"		 		-> enforcePatternMatchingNames = ParsingTools.parseBoolean(value);
 			case "removeEscapes"		 					-> removeEscapes = ParsingTools.parseBoolean(value);
 			case "simplifyFunctionsOfConstants" 			-> simplifyFunctionsOfConstants = ParsingTools.parseBoolean(value);

--- a/core/src/java/show/ezkz/casprzak/core/config/cas.properties
+++ b/core/src/java/show/ezkz/casprzak/core/config/cas.properties
@@ -30,7 +30,7 @@ defaultSleep = 1.5
 enforceEscapes = false
 
 # Denotes whether or not the regex for valid variable, function, and constant names should enforce a LaTeX escape in multi-character names. Enabling this may improve error handling.
-enforceEscapedNames = true
+escapeNames = true
 
 # Denotes whether or not variable, function, and constant names should be checked against the valid name regex {@link ParsingTools#validNames}
 enforcePatternMatchingNames = true

--- a/core/src/java/show/ezkz/casprzak/core/config/cas.properties
+++ b/core/src/java/show/ezkz/casprzak/core/config/cas.properties
@@ -27,7 +27,7 @@ equalsMargin = 1E-10
 defaultSleep = 1.5
 
 # Denotes whether or not expressions like {@code sin(pi/2)} must be escaped to {@code \sin(\pi/2)}. Enabling this is strongly recommended, and may reduce bugs.
-enforceEscapedFunctions = false
+enforceEscapes = false
 
 # Denotes whether or not the regex for valid variable, function, and constant names should enforce a LaTeX escape in multi-character names. Enabling this may improve error handling.
 enforceEscapedNames = true

--- a/core/src/java/show/ezkz/casprzak/core/tools/ParsingTools.java
+++ b/core/src/java/show/ezkz/casprzak/core/tools/ParsingTools.java
@@ -18,7 +18,7 @@ public class ParsingTools {
 	/**
 	 * Matches all valid variable, function, and constant names
 	 */
-	public static final Pattern validNames = Pattern.compile("[a-zA-Z[^\\x00-\\x7F]]|\\\\" + (Settings.enforceEscapedNames ? "" : "?") + "[a-zA-Z[^\\x00-\\x7F]][\\w.'[^\\x00-\\x7F]]*");
+	public static final Pattern validNames = Pattern.compile("[a-zA-Z[^\\x00-\\x7F]]|\\\\" + (Settings.escapeNames ? "" : "?") + "[a-zA-Z[^\\x00-\\x7F]][\\w.'[^\\x00-\\x7F]]*");
 
 	private ParsingTools(){}
 

--- a/parsing/src/java/show/ezkz/casprzak/parsing/FunctionParser.java
+++ b/parsing/src/java/show/ezkz/casprzak/parsing/FunctionParser.java
@@ -80,7 +80,7 @@ public class FunctionParser {
 	 * @return an array of postfix tokens
 	 */
 	public static List<String> toPostfix(String infix) {
-		if (!Settings.enforceEscapedFunctions)
+		if (!Settings.enforceEscapes)
 			infix = LatexReplacer.addEscapes(infix);
 		infix = LatexReplacer.encodeMappings(infix);
 		List<String> tokens = InfixTokenizer.tokenizeInfix(infix);

--- a/parsing/src/java/show/ezkz/casprzak/parsing/LatexReplacer.java
+++ b/parsing/src/java/show/ezkz/casprzak/parsing/LatexReplacer.java
@@ -92,7 +92,7 @@ public class LatexReplacer {
 	 * @return the encoded input
 	 */
 	public static String encodeAll(String input) {
-		if (!Settings.enforceEscapedFunctions)
+		if (!Settings.enforceEscapes)
 			input = LatexReplacer.addEscapes(input);
 		input = LatexReplacer.encodeMappings(input);
 		return input;

--- a/tests/NoEscapeTest.java
+++ b/tests/NoEscapeTest.java
@@ -13,86 +13,86 @@ public class NoEscapeTest {
 
 	@Test
 	void sinPi() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test = FunctionParser.parseInfix("pi (1+1)+sin(pi/2)");
 		assertEquals(7.3, test.evaluate(Map.of("x", 3.2)), .3);
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test
 	void log() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test = FunctionParser.parseInfix("log(x)+log(1)");
 		assertEquals(1, test.evaluate(Map.of("x", 10.0)), .3);
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test
 	void distributeTerms() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test1 = FunctionParser.parseInfix("sin(x)*(1+5x)");
 		GeneralFunction test2 = FunctionParser.parseInfix("sin(x)+5*x*sin(x)");
 		assertEquals(((Product)test1).distributeAll(), test2);
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test
 	void exp() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test = FunctionParser.parseInfix("exp(ln(x))");
 		assertEquals(4, test.evaluate(Map.of("x", 4.0)), .01);
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test
 	void simpleInverseLnAndExp() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test1 = FunctionParser.parseInfix("exp(ln(x))");
 		GeneralFunction test2 = FunctionParser.parseInfix("ln(exp(x))");
 		assertEquals(test1.simplify(), test2.simplify());
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test
 	void simpleInverseTrig() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test1 = FunctionParser.parseInfix("asin(sin(x))");
 		GeneralFunction test2 = FunctionParser.parseInfix("cos(acos(x))");
 		assertEquals(test1.simplify(), test2.simplify());
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test
 	void inverseChain() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test1 = FunctionParser.parseInfix("asin(acos(exp(ln(sec(asec(cos(sin(x))))))))");
 		assertEquals(DefaultFunctions.X, test1.simplify()); // this isn"t actually correct based on ranges, so if you add that this will break
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test
 	void expInverses() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test1 = FunctionParser.parseSimplified("ln(e^logb_e(exp(x)))");
 		assertEquals(DefaultFunctions.X, test1);
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test
 	void logFOC() {
-		boolean temp = Settings.enforceEscapedFunctions;
-		Settings.enforceEscapedFunctions = false;
+		boolean temp = Settings.enforceEscapes;
+		Settings.enforceEscapes = false;
 		GeneralFunction test1 = FunctionParser.parseSimplified("log(100)");
 		assertEquals(DefaultFunctions.TWO, test1);
-		Settings.enforceEscapedFunctions = temp;
+		Settings.enforceEscapes = temp;
 	}
 
 	@Test


### PR DESCRIPTION
- Fix 'enforceEscapes' not being a setting
- Fix inconsistent variable names in the tutorial
- Fix the CAS automatically simplifying expressions in the simplify section