### PR TITLE
Make KeywordInterface reset method reset stored error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
  - Fix inputs like `sinner` being parsed to the variable `\sinner` rather than a product
  - Fix inconsistent variable names in the tutorial
  - Fix CASDemo automatically simplifying expressions in the SIMP section
+ - Fix `reset` in `KeywordInterface` not clearing the stored error `prevException`
 
 
 ## v0.2.1

--- a/commandui/src/java/show/ezkz/casprzak/commandui/KeywordInterface.java
+++ b/commandui/src/java/show/ezkz/casprzak/commandui/KeywordInterface.java
@@ -424,6 +424,8 @@ public class KeywordInterface {
 	private static String reset() {
 		clearFunctions();
 		Constant.resetConstants();
+		prevException = null;
+		// `prev` does not need to be reset because it is set to "Reset done" by the return value
 		return "Reset done.";
 	}
 


### PR DESCRIPTION
Fixes bug where errors are not reset when `reset` is called